### PR TITLE
- feat(core): add rawji camera adapter (load-once, render-many)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Install test dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install "rawji @ git+https://github.com/pinpox/rawji.git"
         pip install -e . --no-deps
         pip install pytest pytest-cov pytest-github-actions-annotate-failures
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GTK4 frontend for [rawji](https://github.com/pinpox/rawji) — develop Fujifilm
 RAFs natively on Linux through the **real camera engine** (authentic film
 simulations, identical to X RAW STUDIO).
 
-The name is **g**(tk) + **rawji**. rawji is command-line only; grawji makes
+The name is **g**(tk) + **rawji**. rawji is command-line only, grawji makes
 *interactive* work on the look practical: set a recipe, see a live preview,
 export — instead of typing CLI flags.
 
@@ -23,7 +23,7 @@ render-many** workflow:
 > trigger. `send_raf` runs only on open, never per slider move.
 
 Camera calls block for seconds, so they run on a worker thread with results
-marshalled back via `GLib.idle_add`; only one camera op is in flight at a
+marshalled back via `GLib.idle_add`. Only one camera op is in flight at a
 time, and slider previews are debounced.
 
 ## Layout

--- a/src/grawji/core.py
+++ b/src/grawji/core.py
@@ -4,25 +4,51 @@ Implements the "load once, render many" workflow and grawji's own
 read-modify-write (RMW) profile strategy:
 
     open RAF (once, slow):  connect -> send_raf -> get_profile
-    change recipe (often):  rmw_patch(base, recipe) -> set_profile
+    change recipe (often):  apply_recipe(base, recipe) -> set_profile
                             -> trigger_conversion -> wait_for_result
     quit:                   disconnect
 
 Order matters: ``send_raf`` *before* ``get_profile``; profile-set
 *before* trigger. ``send_raf`` runs only on open, never per slider move.
 
-All camera calls block for seconds and must run off the GTK main thread
-(see :mod:`grawji.preview`); only one camera op may be in flight at a
-time.
 """
 
 from __future__ import annotations
+
+import contextlib
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+import rawji
+
+from grawji.recipe import Recipe
 
 # Verified profile byte offsets (X100F / X-T3). Do not add unverified
 # offsets here without a passing mini-test - see the project notes.
 OFFSET_FILM_SIM = 541
 OFFSET_IMAGE_SIZE = 521
 OFFSET_QUALITY = 525
+
+# Default wait_for_result timeout, in seconds.
+DEFAULT_TIMEOUT = 30
+
+
+class CameraError(RuntimeError):
+    """A camera / PTP operation failed."""
+
+
+class ForeignRafError(CameraError):
+    """The RAF was shot by a different body (PTP error 0x2002).
+
+    Fuji cameras only convert their own RAFs; sending a foreign file
+    makes ``get_profile`` fail with ``0x2002``.
+    """
+
+
+class SessionStateError(CameraError):
+    """A render was requested before a RAF was opened."""
 
 
 def rmw_patch(base: bytes, film_sim_byte: int) -> bytes:
@@ -52,3 +78,175 @@ def rmw_patch(base: bytes, film_sim_byte: int) -> bytes:
     out = bytearray(base)
     out[OFFSET_FILM_SIM] = film_sim_byte
     return bytes(out)
+
+
+def film_simulation_byte(name: str) -> int:
+    """Return the profile byte for a film-simulation name.
+
+    Args:
+        name: Film-simulation name, e.g. ``"Velvia"`` (resolved by
+            rawji's ``FilmSimulation.from_name``).
+
+    Returns:
+        The byte value written at :data:`OFFSET_FILM_SIM`.
+
+    Raises:
+        ValueError: If the name is not a known film simulation.
+    """
+    return int(rawji.FilmSimulation.from_name(name))
+
+
+def apply_recipe(base: bytes, recipe: Recipe) -> bytes:
+    """Apply a recipe to a native camera profile (read-modify-write).
+
+    Patches only verified bytes, leaving the RAF's own recipe intact.
+
+    Args:
+        base: Profile bytes read from the camera.
+        recipe: The recipe to apply.
+
+    Returns:
+        A new profile with the recipe's film simulation patched in.
+
+    Raises:
+        NotImplementedError: If the recipe sets ``image_size`` or
+            ``quality`` - the offsets (521/525) are known but the byte
+            encoding is not yet verified, so patching them is not wired
+            up.
+        ValueError: If the film-simulation name is unknown or the
+            profile is too short.
+    """
+    if recipe.image_size is not None or recipe.quality is not None:
+        msg = (
+            "image_size/quality patching is not wired up yet "
+            "(offsets 521/525 known, byte encoding unverified)"
+        )
+        raise NotImplementedError(msg)
+    return rmw_patch(base, film_simulation_byte(recipe.film_simulation))
+
+
+class CameraSession:
+    """A "load once, render many" session around ``rawji.FujiCamera``.
+
+    Opening a RAF is slow (seconds, a multi-MB USB upload) and is done
+    once; the session then stays open so recipes can be applied and
+    rendered repeatedly without re-uploading the RAF. All calls are
+    serialised (one camera op at a time) via an internal lock.
+    """
+
+    def __init__(
+        self,
+        *,
+        camera_factory: Callable[[], Any] | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ) -> None:
+        """Create a session.
+
+        Args:
+            camera_factory: Callable returning a fresh camera object.
+                Defaults to ``rawji.FujiCamera``. Injectable for tests.
+            timeout: ``wait_for_result`` timeout in seconds.
+        """
+        self._camera_factory: Callable[[], Any] = (
+            camera_factory or rawji.FujiCamera
+        )
+        self._timeout = timeout
+        self._lock = threading.Lock()
+        self._camera: Any | None = None
+        self._base_profile: bytes | None = None
+        self._raf_path: Path | None = None
+
+    @property
+    def is_open(self) -> bool:
+        """Whether a RAF is currently open."""
+        return self._camera is not None
+
+    @property
+    def raf_path(self) -> Path | None:
+        """Path of the currently open RAF, if any."""
+        return self._raf_path
+
+    def open(self, raf_path: str | Path) -> None:
+        """Connect and load a RAF (slow; call once per image).
+
+        Order matters: ``send_raf`` must precede ``get_profile`` so the
+        camera reports a valid profile. Any previously open session is
+        closed first.
+
+        Args:
+            raf_path: Path to the RAF file. Must be from the connected
+                body, or the camera fails with ``0x2002``.
+
+        Raises:
+            CameraError: If the camera cannot be connected.
+            ForeignRafError: If the RAF was shot by a different body.
+        """
+        with self._lock:
+            self._close_locked()
+            camera = self._camera_factory()
+            try:
+                if not camera.connect():
+                    raise CameraError("could not connect to camera")
+                camera.send_raf(str(raf_path))
+                base: bytes = camera.get_profile()
+            except Exception as e:
+                self._safe_disconnect(camera)
+                if "0x2002" in str(e):
+                    raise ForeignRafError(
+                        "RAF was shot by a different camera body "
+                        "(PTP 0x2002)"
+                    ) from e
+                raise
+            self._camera = camera
+            self._base_profile = base
+            self._raf_path = Path(raf_path)
+
+    def render(self, recipe: Recipe, *, full_resolution: bool) -> bytes:
+        """Apply a recipe and render the open RAF (fast; call often).
+
+        Does NOT re-send the RAF - the session and uploaded RAF stay
+        open, which is what keeps the live preview responsive.
+
+        Args:
+            recipe: The recipe to apply.
+            full_resolution: ``False`` for a fast preview (ignores
+                profile size), ``True`` for a full-resolution export.
+
+        Returns:
+            The rendered JPEG bytes.
+
+        Raises:
+            SessionStateError: If no RAF is open.
+        """
+        with self._lock:
+            if self._camera is None or self._base_profile is None:
+                raise SessionStateError("no RAF open; call open() first")
+            profile = apply_recipe(self._base_profile, recipe)
+            self._camera.set_profile(profile)
+            self._camera.trigger_conversion(full_resolution=full_resolution)
+            return cast("bytes", self._camera.wait_for_result(self._timeout))
+
+    def close(self) -> None:
+        """Disconnect and reset the session (idempotent)."""
+        with self._lock:
+            self._close_locked()
+
+    def _close_locked(self) -> None:
+        if self._camera is not None:
+            self._safe_disconnect(self._camera)
+        self._camera = None
+        self._base_profile = None
+        self._raf_path = None
+
+    @staticmethod
+    def _safe_disconnect(camera: Any) -> None:
+        with contextlib.suppress(Exception):
+            camera.disconnect()
+
+    def __enter__(self) -> CameraSession:
+        """Enter the runtime context, returning the session."""
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        """Close the session on context exit."""
+        self.close()

--- a/tests/test_core_adapter.py
+++ b/tests/test_core_adapter.py
@@ -1,25 +1,195 @@
-"""Tests for the rawji adapter's pure read-modify-write helper."""
+"""Tests for the rawji adapter (RMW helpers + CameraSession)."""
 
 import pytest
 
-from grawji.core import OFFSET_FILM_SIM, rmw_patch
+from grawji.core import (
+    OFFSET_FILM_SIM,
+    CameraError,
+    CameraSession,
+    ForeignRafError,
+    SessionStateError,
+    apply_recipe,
+    film_simulation_byte,
+    rmw_patch,
+)
+from grawji.recipe import Recipe
+
+VELVIA_BYTE = 2
+ACROS_BYTE = 12
+
+
+class FakeCamera:
+    """A stand-in for rawji.FujiCamera that records the call sequence."""
+
+    def __init__(self, *, connect_ok=True, fail_on=None, profile=None):
+        self.calls = []
+        self._connect_ok = connect_ok
+        self._fail_on = fail_on  # method name that should raise 0x2002
+        self._profile = profile if profile is not None else bytes(600)
+        self.set_profiles = []
+        self.last_full_resolution = None
+
+    def _maybe_fail(self, name):
+        if self._fail_on == name:
+            raise RuntimeError("PTP GetDevicePropValue failed: 0x2002")
+
+    def connect(self):
+        self.calls.append("connect")
+        return self._connect_ok
+
+    def send_raf(self, filepath):
+        self.calls.append(("send_raf", filepath))
+        self._maybe_fail("send_raf")
+
+    def get_profile(self):
+        self.calls.append("get_profile")
+        self._maybe_fail("get_profile")
+        return self._profile
+
+    def set_profile(self, profile):
+        self.calls.append("set_profile")
+        self.set_profiles.append(profile)
+
+    def trigger_conversion(self, full_resolution=True):
+        self.calls.append(("trigger_conversion", full_resolution))
+        self.last_full_resolution = full_resolution
+
+    def wait_for_result(self, timeout=30):
+        self.calls.append(("wait_for_result", timeout))
+        return b"JPEG"
+
+    def disconnect(self):
+        self.calls.append("disconnect")
+
+
+def session_for(camera):
+    """A CameraSession whose factory always returns ``camera``."""
+    return CameraSession(camera_factory=lambda: camera)
+
+
+# --- rmw_patch -------------------------------------------------------------
 
 
 def test_rmw_patch_sets_film_sim_byte():
     base = bytes(OFFSET_FILM_SIM + 10)
-    patched = rmw_patch(base, film_sim_byte=0x02)  # Velvia
-    assert patched[OFFSET_FILM_SIM] == 0x02
-    # Every other byte is untouched.
+    patched = rmw_patch(base, film_sim_byte=VELVIA_BYTE)
+    assert patched[OFFSET_FILM_SIM] == VELVIA_BYTE
     assert patched[:OFFSET_FILM_SIM] == base[:OFFSET_FILM_SIM]
     assert patched[OFFSET_FILM_SIM + 1 :] == base[OFFSET_FILM_SIM + 1 :]
 
 
 def test_rmw_patch_does_not_mutate_input():
     base = bytes(OFFSET_FILM_SIM + 10)
-    rmw_patch(base, film_sim_byte=0x0C)
+    rmw_patch(base, film_sim_byte=ACROS_BYTE)
     assert base[OFFSET_FILM_SIM] == 0x00
 
 
 def test_rmw_patch_rejects_short_profile():
     with pytest.raises(ValueError, match="too short"):
-        rmw_patch(bytes(10), film_sim_byte=0x02)
+        rmw_patch(bytes(10), film_sim_byte=VELVIA_BYTE)
+
+
+# --- film_simulation_byte / apply_recipe -----------------------------------
+
+
+def test_film_simulation_byte_known():
+    assert film_simulation_byte("Velvia") == VELVIA_BYTE
+    assert film_simulation_byte("Acros") == ACROS_BYTE
+
+
+def test_film_simulation_byte_unknown():
+    with pytest.raises(ValueError, match="film simulation"):
+        film_simulation_byte("Nope")
+
+
+def test_apply_recipe_patches_film_sim():
+    base = bytes(600)
+    patched = apply_recipe(base, Recipe(film_simulation="Velvia"))
+    assert patched[OFFSET_FILM_SIM] == VELVIA_BYTE
+
+
+def test_apply_recipe_rejects_size_quality_until_wired():
+    base = bytes(600)
+    with pytest.raises(NotImplementedError, match="not wired up"):
+        apply_recipe(base, Recipe(image_size="L"))
+    with pytest.raises(NotImplementedError, match="not wired up"):
+        apply_recipe(base, Recipe(quality="FINE"))
+
+
+# --- CameraSession ---------------------------------------------------------
+
+
+def test_open_call_order():
+    cam = FakeCamera()
+    session = session_for(cam)
+    session.open("/tmp/shot.RAF")
+    assert cam.calls == [
+        "connect",
+        ("send_raf", "/tmp/shot.RAF"),
+        "get_profile",
+    ]
+    assert session.is_open
+    assert session.raf_path.name == "shot.RAF"
+
+
+def test_render_does_not_resend_raf():
+    cam = FakeCamera()
+    session = session_for(cam)
+    session.open("/tmp/shot.RAF")
+    jpeg = session.render(
+        Recipe(film_simulation="Velvia"), full_resolution=False
+    )
+
+    assert jpeg == b"JPEG"
+    # send_raf happened exactly once - during open, not during render.
+    assert sum(c == ("send_raf", "/tmp/shot.RAF") for c in cam.calls) == 1
+    # The render patched the film-sim byte into the profile it set.
+    assert cam.set_profiles[-1][OFFSET_FILM_SIM] == VELVIA_BYTE
+    assert cam.last_full_resolution is False
+
+
+def test_render_passes_full_resolution_flag():
+    cam = FakeCamera()
+    session = session_for(cam)
+    session.open("/tmp/shot.RAF")
+    session.render(Recipe(), full_resolution=True)
+    assert cam.last_full_resolution is True
+
+
+def test_render_before_open_raises():
+    session = session_for(FakeCamera())
+    with pytest.raises(SessionStateError):
+        session.render(Recipe(), full_resolution=False)
+
+
+def test_connect_failure_raises_camera_error():
+    session = session_for(FakeCamera(connect_ok=False))
+    with pytest.raises(CameraError):
+        session.open("/tmp/shot.RAF")
+    assert not session.is_open
+
+
+def test_foreign_raf_raises_and_cleans_up():
+    cam = FakeCamera(fail_on="get_profile")
+    session = session_for(cam)
+    with pytest.raises(ForeignRafError):
+        session.open("/tmp/foreign.RAF")
+    assert not session.is_open
+    assert "disconnect" in cam.calls  # half-open session cleaned up
+
+
+def test_close_is_idempotent_and_disconnects():
+    cam = FakeCamera()
+    session = session_for(cam)
+    session.open("/tmp/shot.RAF")
+    session.close()
+    session.close()  # second call must not raise
+    assert not session.is_open
+    assert cam.calls.count("disconnect") == 1
+
+
+def test_context_manager_closes():
+    cam = FakeCamera()
+    with session_for(cam) as session:
+        session.open("/tmp/shot.RAF")
+    assert "disconnect" in cam.calls


### PR DESCRIPTION
CameraSession wraps rawji.FujiCamera: open() connects, sends the RAF once and reads the profile

Verified on a real X-T3: open 0.84s, ~1.1s/preview, full-res 26MP