### PR TITLE
feat(preview): add CameraWorker for async camera operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ dist/
 # Compiled GResource bundles / generated UI
 src/grawji/ui/*.gresource
 
+# Cambalache design project
+*.cmb
+*.cmb.bak
+
 # Sample / scratch image data (RAFs, JPEGs)
 *.RAF
 *.raf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ grawji = "grawji.__main__:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/grawji"]
+exclude = ["**/*.cmb", "**/*.cmb.bak"]
 
 [tool.ruff]
 line-length = 79
@@ -125,9 +126,16 @@ module = ["gi.*", "rawji.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = ["grawji.app", "grawji.window", "grawji.__main__"]
+module = [
+  "grawji.app",
+  "grawji.window",
+  "grawji.filmstrip",
+  "grawji.__main__",
+]
 disallow_subclassing_any = false
 warn_return_any = false
+# @Gtk.Template / @Gtk.Template.Callback are untyped (gi) decorators.
+disable_error_code = ["untyped-decorator", "misc"]
 
 [[tool.mypy.overrides]]
 module = "tests.*"
@@ -153,6 +161,7 @@ omit = [
   "**/__main__.py",
   "src/grawji/app.py",
   "src/grawji/window.py",
+  "src/grawji/filmstrip.py",
   "src/grawji/ui/**",
 ]
 

--- a/src/grawji/app.py
+++ b/src/grawji/app.py
@@ -1,24 +1,29 @@
-"""Gtk.Application wiring."""
+"""Adw.Application wiring."""
 
 from __future__ import annotations
 
 import gi
 
 gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
 
-from gi.repository import Gtk  # noqa: E402
+from gi.repository import Adw  # noqa: E402
 
 from grawji.window import MainWindow  # noqa: E402
 
 
-class GrawjiApp(Gtk.Application):
-    """The grawji GTK4 application."""
+class GrawjiApp(Adw.Application):
+    """The grawji application.
+
+    Built on ``Adw.Application`` so it follows the system light/dark
+    colour scheme and accent colour via libadwaita's style manager.
+    """
 
     def __init__(self) -> None:
         """Initialise the application with its reverse-DNS id."""
         super().__init__(application_id="io.github.p5k369.grawji")
 
     def do_activate(self) -> None:
-        """Create and present the main window on activation."""
-        window = MainWindow(application=self)
+        """Present the main window, reusing it if it already exists."""
+        window = self.props.active_window or MainWindow(application=self)
         window.present()

--- a/src/grawji/core.py
+++ b/src/grawji/core.py
@@ -232,6 +232,7 @@ class CameraSession:
             self._close_locked()
 
     def _close_locked(self) -> None:
+        """Disconnect and reset session state (caller holds the lock)."""
         if self._camera is not None:
             self._safe_disconnect(self._camera)
         self._camera = None
@@ -240,6 +241,7 @@ class CameraSession:
 
     @staticmethod
     def _safe_disconnect(camera: Any) -> None:
+        """Disconnect a camera, ignoring any teardown errors."""
         with contextlib.suppress(Exception):
             camera.disconnect()
 

--- a/src/grawji/filmstrip.py
+++ b/src/grawji/filmstrip.py
@@ -1,0 +1,132 @@
+"""Bottom filmstrip of RAF thumbnails."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+
+from gi.repository import Gdk, GdkPixbuf, GLib, Gtk  # noqa: E402
+
+from grawji.raf import embedded_jpeg  # noqa: E402
+
+Dispatch = Callable[[Callable[[], None]], Any]
+
+
+class FilmStrip(Gtk.ScrolledWindow):
+    """A horizontally-scrolling strip of clickable RAF thumbnails."""
+
+    def __init__(
+        self,
+        *,
+        on_select: Callable[[str], None],
+        dispatch: Dispatch = GLib.idle_add,
+        thumb_height: int = 110,
+    ) -> None:
+        """Create the filmstrip.
+
+        Args:
+            on_select: Called with the RAF path when a thumbnail is
+                clicked.
+            dispatch: Schedules a callback on the GTK main loop.
+            thumb_height: Thumbnail height in pixels.
+        """
+        super().__init__()
+        self._on_select = on_select
+        self._dispatch = dispatch
+        self._thumb_height = thumb_height
+        self._scan_id = 0
+
+        self.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.NEVER)
+        self._box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
+        self._box.set_margin_start(4)
+        self._box.set_margin_end(4)
+        self._box.set_margin_top(4)
+        self._box.set_margin_bottom(4)
+        self.set_child(self._box)
+        self.set_min_content_height(thumb_height + 16)
+
+    def scan(self, folder: str) -> None:
+        """Populate the strip with the RAF files in ``folder``."""
+        self._scan_id += 1
+        scan_id = self._scan_id
+        self._clear()
+
+        base = Path(folder)
+        paths = sorted(
+            {p for pat in ("*.RAF", "*.raf") for p in base.glob(pat)}
+        )
+        pictures = []
+        for path in paths:
+            picture = Gtk.Picture()
+            picture.set_size_request(
+                int(self._thumb_height * 1.5), self._thumb_height
+            )
+            button = Gtk.Button(child=picture)
+            button.add_css_class("flat")
+            button.set_tooltip_text(path.name)
+            button.connect("clicked", partial(self._on_clicked, str(path)))
+            self._box.append(button)
+            pictures.append((str(path), picture))
+
+        if pictures:
+            threading.Thread(
+                target=self._load_thumbnails,
+                args=(pictures, scan_id),
+                name="grawji-thumbs",
+                daemon=True,
+            ).start()
+
+    def _clear(self) -> None:
+        """Remove all thumbnails currently in the strip."""
+        child = self._box.get_first_child()
+        while child is not None:
+            nxt = child.get_next_sibling()
+            self._box.remove(child)
+            child = nxt
+
+    def _on_clicked(self, path: str, _button: Gtk.Button) -> None:
+        """Notify the listener that a thumbnail was clicked."""
+        self._on_select(path)
+
+    def _load_thumbnails(
+        self, pictures: list[tuple[str, Any]], scan_id: int
+    ) -> None:
+        """Decode each RAF's thumbnail off-thread and dispatch it."""
+        for path, picture in pictures:
+            if scan_id != self._scan_id:
+                return  # a newer scan superseded this one
+            try:
+                pixbuf = self._decode_thumb(embedded_jpeg(path))
+            except (ValueError, OSError, GLib.Error):
+                continue  # skip unreadable / non-RAF files
+            self._dispatch(
+                partial(self._apply_thumb, picture, pixbuf, scan_id)
+            )
+
+    def _decode_thumb(self, jpeg: bytes) -> Any:
+        """Decode JPEG bytes into a thumbnail-sized, oriented pixbuf."""
+        loader = GdkPixbuf.PixbufLoader()
+        loader.connect("size-prepared", self._scale_to_thumb)
+        loader.write(jpeg)
+        loader.close()
+        pixbuf = loader.get_pixbuf()
+        return pixbuf.apply_embedded_orientation() or pixbuf
+
+    def _scale_to_thumb(self, loader: Any, width: int, height: int) -> None:
+        """Scale the image to the thumbnail height, keeping aspect."""
+        if height <= 0:
+            return
+        scale = self._thumb_height / height
+        loader.set_size(max(1, int(width * scale)), self._thumb_height)
+
+    def _apply_thumb(self, picture: Any, pixbuf: Any, scan_id: int) -> None:
+        """Set the thumbnail on its picture if the scan is still current."""
+        if scan_id == self._scan_id:
+            picture.set_paintable(Gdk.Texture.new_for_pixbuf(pixbuf))

--- a/src/grawji/preview.py
+++ b/src/grawji/preview.py
@@ -1,13 +1,4 @@
-"""Preview pipeline - run camera ops off the GTK main thread.
-
-Camera operations block for ~1s. Running them on the GTK main thread would
-freeze the UI, so :class:`CameraWorker` runs them on a single background
-thread and delivers results via a ``dispatch`` callable - the GTK layer
-passes ``GLib.idle_add`` so the callbacks run back on the main loop.
-
-This module stays free of GTK/GLib - ``dispatch`` is injected - so it is
-unit-testable without a display.
-"""
+"""Preview pipeline - run camera ops off the GTK main thread."""
 
 from __future__ import annotations
 
@@ -125,6 +116,7 @@ class CameraWorker:
         *,
         coalesce: bool,
     ) -> None:
+        """Queue a job, coalescing a trailing render when asked."""
         with self._cond:
             # A new render replaces a trailing render that has not yet
             # started - the latest recipe is the only one worth rendering.
@@ -135,6 +127,7 @@ class CameraWorker:
             self._cond.notify()
 
     def _loop(self) -> None:
+        """Process queued jobs on the worker thread until stopped."""
         while True:
             with self._cond:
                 while not self._queue and self._running:
@@ -145,6 +138,7 @@ class CameraWorker:
             self._run(job)
 
     def _run(self, job: _Job) -> None:
+        """Run one job and dispatch its result or error."""
         task, on_done, on_error, _ = job
         try:
             result = task()

--- a/src/grawji/raf.py
+++ b/src/grawji/raf.py
@@ -1,0 +1,60 @@
+"""Read the JPEG preview embedded in a Fujifilm RAF file."""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+RAF_MAGIC = b"FUJIFILMCCD-RAW "
+# The header stores the embedded-JPEG offset and length as big-endian
+# uint32 at these byte positions.
+_JPEG_OFFSET_POS = 84
+_JPEG_LENGTH_POS = 88
+_HEADER_MIN = _JPEG_LENGTH_POS + 4
+_JPEG_SOI = b"\xff\xd8"
+
+
+def embedded_jpeg(path: str | Path) -> bytes:
+    """Return the JPEG preview embedded in a RAF file.
+
+    Args:
+        path: Path to the ``.RAF`` file.
+
+    Returns:
+        The embedded JPEG bytes.
+
+    Raises:
+        ValueError: If the file is not a RAF or has no embedded JPEG.
+    """
+    return embedded_jpeg_from_bytes(Path(path).read_bytes())
+
+
+def embedded_jpeg_from_bytes(data: bytes) -> bytes:
+    """Extract the embedded JPEG from raw RAF bytes.
+
+    Args:
+        data: The full contents of a RAF file.
+
+    Returns:
+        The embedded JPEG bytes.
+
+    Raises:
+        ValueError: If the bytes are not a RAF or hold no embedded JPEG.
+    """
+    if not data.startswith(RAF_MAGIC):
+        msg = "not a Fujifilm RAF file (bad magic)"
+        raise ValueError(msg)
+    if len(data) < _HEADER_MIN:
+        msg = "RAF header too short"
+        raise ValueError(msg)
+    offset = struct.unpack(
+        ">I", data[_JPEG_OFFSET_POS : _JPEG_OFFSET_POS + 4]
+    )[0]
+    length = struct.unpack(
+        ">I", data[_JPEG_LENGTH_POS : _JPEG_LENGTH_POS + 4]
+    )[0]
+    jpeg = data[offset : offset + length]
+    if len(jpeg) != length or not jpeg.startswith(_JPEG_SOI):
+        msg = "RAF has no valid embedded JPEG"
+        raise ValueError(msg)
+    return jpeg

--- a/src/grawji/ui/grawji.ui
+++ b/src/grawji/ui/grawji.ui
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <requires lib="libadwaita" version="1.0"/>
+  <template class="MainWindow" parent="AdwApplicationWindow">
+    <property name="title">grawji</property>
+    <property name="default-width">1280</property>
+    <property name="default-height">860</property>
+    <property name="content">
+      <object class="AdwToolbarView">
+        <child type="top">
+          <object class="AdwHeaderBar">
+            <child type="start">
+              <object class="GtkButton">
+                <property name="label">Open Folder…</property>
+                <signal name="clicked" handler="_on_open_folder_clicked"/>
+              </object>
+            </child>
+            <child type="start">
+              <object class="GtkButton" id="rotate_left">
+                <property name="icon-name">object-rotate-left-symbolic</property>
+                <property name="tooltip-text">Rotate left</property>
+                <property name="sensitive">false</property>
+                <signal name="clicked" handler="_on_rotate_left"/>
+              </object>
+            </child>
+            <child type="start">
+              <object class="GtkButton" id="rotate_right">
+                <property name="icon-name">object-rotate-right-symbolic</property>
+                <property name="tooltip-text">Rotate right</property>
+                <property name="sensitive">false</property>
+                <signal name="clicked" handler="_on_rotate_right"/>
+              </object>
+            </child>
+            <child type="end">
+              <object class="GtkButton" id="export_button">
+                <property name="label">Export…</property>
+                <property name="sensitive">false</property>
+                <signal name="clicked" handler="_on_export_clicked"/>
+              </object>
+            </child>
+          </object>
+        </child>
+        <property name="content">
+          <object class="GtkBox">
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkPaned">
+                <property name="vexpand">true</property>
+                <property name="resize-start-child">true</property>
+                <property name="resize-end-child">false</property>
+                <property name="shrink-end-child">false</property>
+                <property name="start-child">
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkOverlay">
+                        <property name="vexpand">true</property>
+                        <child>
+                          <object class="GtkPicture" id="picture"/>
+                        </child>
+                        <child type="overlay">
+                          <object class="GtkSpinner" id="spinner">
+                            <property name="halign">center</property>
+                            <property name="valign">center</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="status">
+                        <property name="label">Open a folder to begin.</property>
+                        <property name="xalign">0</property>
+                        <property name="margin-start">4</property>
+                        <property name="margin-end">4</property>
+                        <property name="margin-top">4</property>
+                        <property name="margin-bottom">4</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+                <property name="end-child">
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <property name="width-request">280</property>
+                    <property name="margin-start">10</property>
+                    <property name="margin-end">10</property>
+                    <property name="margin-top">10</property>
+                    <property name="margin-bottom">10</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label">Recipe</property>
+                        <property name="xalign">0</property>
+                        <style>
+                          <class name="title-4"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label">Film Simulation</property>
+                        <property name="xalign">0</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkDropDown" id="film_dropdown">
+                        <property name="sensitive">false</property>
+                        <signal name="notify::selected"
+                                handler="_on_film_changed"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label">More controls coming soon…</property>
+                        <property name="xalign">0</property>
+                        <property name="margin-top">12</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSeparator"/>
+            </child>
+            <child>
+              <object class="GtkBox" id="filmstrip_slot">
+                <property name="orientation">vertical</property>
+              </object>
+            </child>
+          </object>
+        </property>
+      </object>
+    </property>
+  </template>
+</interface>

--- a/src/grawji/window.py
+++ b/src/grawji/window.py
@@ -1,19 +1,235 @@
-"""Main application window."""
+"""Main application window (layout in ui/grawji.ui via Gtk.Template)."""
 
 from __future__ import annotations
+
+from functools import partial
+from importlib import resources
+from pathlib import Path
+from typing import Any
 
 import gi
 
 gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
 
-from gi.repository import Gtk  # noqa: E402
+import rawji  # noqa: E402
+from gi.repository import Adw, Gdk, GdkPixbuf, GLib, Gtk  # noqa: E402
+
+from grawji import raf  # noqa: E402
+from grawji.core import CameraSession, ForeignRafError  # noqa: E402
+from grawji.filmstrip import FilmStrip  # noqa: E402
+from grawji.preview import CameraWorker  # noqa: E402
+from grawji.recipe import Recipe  # noqa: E402
+
+# Film-simulation names offered in the dropdown (rawji's enum order).
+_FILM_SIMULATIONS = [e.name for e in rawji.FilmSimulation]
+
+# Manual rotation (degrees clockwise) -> GdkPixbuf rotation.
+_ROTATIONS = {
+    90: GdkPixbuf.PixbufRotation.CLOCKWISE,
+    180: GdkPixbuf.PixbufRotation.UPSIDEDOWN,
+    270: GdkPixbuf.PixbufRotation.COUNTERCLOCKWISE,
+}
+
+# The layout lives in grawji.ui (shipped as package data, designed in
+# Cambalache); Gtk.Template binds it to this class at runtime.
+_UI = (
+    resources.files("grawji")
+    .joinpath("ui", "grawji.ui")
+    .read_text(encoding="utf-8")
+)
 
 
-class MainWindow(Gtk.ApplicationWindow):
-    """grawji main window: open RAF, tune recipe, preview, export."""
+@Gtk.Template(string=_UI)
+class MainWindow(Adw.ApplicationWindow):
+    """grawji main window: browse RAFs, tune recipe, preview, export."""
+
+    __gtype_name__ = "MainWindow"
+
+    picture = Gtk.Template.Child()
+    spinner = Gtk.Template.Child()
+    status = Gtk.Template.Child()
+    film_dropdown = Gtk.Template.Child()
+    rotate_left = Gtk.Template.Child()
+    rotate_right = Gtk.Template.Child()
+    export_button = Gtk.Template.Child()
+    filmstrip_slot = Gtk.Template.Child()
 
     def __init__(self, **kwargs: object) -> None:
-        """Build the window shell (placeholder layout)."""
+        """Wire up the camera worker, dropdown model and filmstrip."""
         super().__init__(**kwargs)
-        self.set_title("grawji")
-        self.set_default_size(1024, 768)
+        self._session = CameraSession()
+        self._worker = CameraWorker(self._session, dispatch=GLib.idle_add)
+        self._worker.start()
+        self.connect("close-request", self._on_close_request)
+
+        self._rotation = 0
+        self._last_jpeg: bytes | None = None
+
+        self.film_dropdown.set_model(Gtk.StringList.new(_FILM_SIMULATIONS))
+        self._filmstrip = FilmStrip(on_select=self._on_raf_selected)
+        self.filmstrip_slot.append(self._filmstrip)
+
+    def _current_recipe(self) -> Recipe:
+        """Build a recipe from the current dropdown selection."""
+        name = _FILM_SIMULATIONS[self.film_dropdown.get_selected()]
+        return Recipe(film_simulation=name)
+
+    @Gtk.Template.Callback()
+    def _on_open_folder_clicked(self, _button: Any) -> None:
+        """Show a folder picker to populate the filmstrip."""
+        dialog = Gtk.FileDialog()
+        dialog.set_title("Open folder of RAFs")
+        dialog.select_folder(self, None, self._on_folder_response)
+
+    def _on_folder_response(self, dialog: Any, result: Any) -> None:
+        """Scan the chosen folder, or do nothing if cancelled."""
+        try:
+            gfile = dialog.select_folder_finish(result)
+        except GLib.Error:
+            return
+        path = gfile.get_path()
+        if path is not None:
+            self._filmstrip.scan(path)
+            self.status.set_label("Select an image from the filmstrip.")
+
+    def _on_raf_selected(self, raf_path: str) -> None:
+        """Show the embedded preview instantly, then open the RAF."""
+        self._rotation = 0
+        try:
+            self._show_jpeg(raf.embedded_jpeg(raf_path))
+        except (ValueError, OSError):
+            self._last_jpeg = None
+        self.set_title(f"grawji — {Path(raf_path).name}")
+        self._set_busy(busy=True, status="Loading RAF…")
+        self._worker.open(
+            raf_path, on_done=self._on_opened, on_error=self._on_error
+        )
+
+    def _on_opened(self, _result: object) -> None:
+        """Render the first preview once the RAF is loaded."""
+        self._render_preview()
+
+    @Gtk.Template.Callback()
+    def _on_film_changed(self, _dropdown: Any, _param: Any) -> None:
+        """Re-render the preview when the film simulation changes."""
+        if self._session.is_open:
+            self._render_preview()
+
+    def _render_preview(self) -> None:
+        """Queue a fast (non-full-resolution) preview render."""
+        self._set_busy(busy=True, status="Rendering preview…")
+        self._worker.render(
+            self._current_recipe(),
+            full_resolution=False,
+            on_done=self._on_preview,
+            on_error=self._on_error,
+        )
+
+    def _on_preview(self, jpeg: bytes) -> None:
+        """Display a finished preview render."""
+        self._show_jpeg(jpeg)
+        self._set_busy(busy=False, status="Ready.")
+
+    @Gtk.Template.Callback()
+    def _on_rotate_left(self, _button: Any) -> None:
+        """Rotate the displayed image 90 degrees counter-clockwise."""
+        self._rotate(-90)
+
+    @Gtk.Template.Callback()
+    def _on_rotate_right(self, _button: Any) -> None:
+        """Rotate the displayed image 90 degrees clockwise."""
+        self._rotate(90)
+
+    def _rotate(self, degrees: int) -> None:
+        """Update the rotation and redisplay the current image."""
+        self._rotation = (self._rotation + degrees) % 360
+        if self._last_jpeg is not None:
+            self._show_jpeg(self._last_jpeg)
+
+    @Gtk.Template.Callback()
+    def _on_export_clicked(self, _button: Any) -> None:
+        """Show a save dialog for a full-resolution export."""
+        dialog = Gtk.FileDialog()
+        dialog.set_title("Export JPEG")
+        dialog.set_initial_name("grawji-export.jpg")
+        dialog.save(self, None, self._on_export_response)
+
+    def _on_export_response(self, dialog: Any, result: Any) -> None:
+        """Render at full resolution and write to the chosen path."""
+        try:
+            gfile = dialog.save_finish(result)
+        except GLib.Error:
+            return
+        path = gfile.get_path()
+        if path is None:
+            return
+        self._set_busy(busy=True, status="Rendering full-resolution export…")
+        self._worker.render(
+            self._current_recipe(),
+            full_resolution=True,
+            on_done=partial(self._on_exported, path),
+            on_error=self._on_error,
+        )
+
+    def _on_exported(self, path: str, jpeg: bytes) -> None:
+        """Save the exported JPEG with orientation and rotation baked in."""
+        try:
+            pixbuf = self._pixbuf_from_jpeg(jpeg)
+            pixbuf.savev(path, "jpeg", ["quality"], ["95"])
+        except (GLib.Error, OSError) as exc:
+            self._set_busy(busy=False, status=f"Export failed: {exc}")
+            return
+        self._set_busy(busy=False, status=f"Exported to {path}")
+
+    def _pixbuf_from_jpeg(self, jpeg: bytes) -> Any:
+        """Decode JPEG bytes, applying EXIF orientation and rotation."""
+        loader = GdkPixbuf.PixbufLoader()
+        loader.write(jpeg)
+        loader.close()
+        pixbuf = loader.get_pixbuf().apply_embedded_orientation()
+        rotation = _ROTATIONS.get(self._rotation)
+        return pixbuf.rotate_simple(rotation) if rotation else pixbuf
+
+    def _show_jpeg(self, jpeg: bytes) -> None:
+        """Display JPEG bytes in the preview and remember them."""
+        self._last_jpeg = jpeg
+        try:
+            pixbuf = self._pixbuf_from_jpeg(jpeg)
+        except GLib.Error as exc:
+            self._set_busy(busy=False, status=f"Cannot display image: {exc}")
+            return
+        self.picture.set_paintable(Gdk.Texture.new_for_pixbuf(pixbuf))
+        self.rotate_left.set_sensitive(True)
+        self.rotate_right.set_sensitive(True)
+
+    def _set_busy(self, *, busy: bool, status: str) -> None:
+        """Toggle the spinner and recipe controls, and set the status."""
+        if busy:
+            self.spinner.start()
+        else:
+            self.spinner.stop()
+        enabled = self._session.is_open and not busy
+        self.film_dropdown.set_sensitive(enabled)
+        self.export_button.set_sensitive(enabled)
+        self.status.set_label(status)
+
+    def _on_error(self, exc: Exception) -> None:
+        """Surface a camera error in a dialog and reset the busy state."""
+        if isinstance(exc, ForeignRafError):
+            detail = (
+                "This RAF was shot by a different camera body. Fuji "
+                "cameras only convert their own RAFs."
+            )
+        else:
+            detail = str(exc)
+        self._set_busy(busy=False, status="Error.")
+        alert = Gtk.AlertDialog()
+        alert.set_message("Camera error")
+        alert.set_detail(detail)
+        alert.show(self)
+
+    def _on_close_request(self, _window: Any) -> bool:
+        """Stop the worker (and close the session) before closing."""
+        self._worker.stop()
+        return False

--- a/tests/test_core_adapter.py
+++ b/tests/test_core_adapter.py
@@ -22,6 +22,7 @@ class FakeCamera:
     """A stand-in for rawji.FujiCamera that records the call sequence."""
 
     def __init__(self, *, connect_ok=True, fail_on=None, profile=None):
+        """Configure connect success, a method to fail on, and a profile."""
         self.calls = []
         self._connect_ok = connect_ok
         self._fail_on = fail_on  # method name that should raise 0x2002
@@ -30,47 +31,53 @@ class FakeCamera:
         self.last_full_resolution = None
 
     def _maybe_fail(self, name):
+        """Raise a 0x2002-style error if this method is the failure point."""
         if self._fail_on == name:
             raise RuntimeError("PTP GetDevicePropValue failed: 0x2002")
 
     def connect(self):
+        """Record the call and report the configured connect result."""
         self.calls.append("connect")
         return self._connect_ok
 
     def send_raf(self, filepath):
+        """Record the RAF upload and maybe fail."""
         self.calls.append(("send_raf", filepath))
         self._maybe_fail("send_raf")
 
     def get_profile(self):
+        """Record the profile read, maybe fail, and return the profile."""
         self.calls.append("get_profile")
         self._maybe_fail("get_profile")
         return self._profile
 
     def set_profile(self, profile):
+        """Record the profile that was written."""
         self.calls.append("set_profile")
         self.set_profiles.append(profile)
 
     def trigger_conversion(self, full_resolution=True):
+        """Record the trigger and the requested resolution."""
         self.calls.append(("trigger_conversion", full_resolution))
         self.last_full_resolution = full_resolution
 
     def wait_for_result(self, timeout=30):
+        """Record the wait and return placeholder JPEG bytes."""
         self.calls.append(("wait_for_result", timeout))
         return b"JPEG"
 
     def disconnect(self):
+        """Record the disconnect."""
         self.calls.append("disconnect")
 
 
 def session_for(camera):
-    """A CameraSession whose factory always returns ``camera``."""
+    """Build a CameraSession whose factory always returns ``camera``."""
     return CameraSession(camera_factory=lambda: camera)
 
 
-# --- rmw_patch -------------------------------------------------------------
-
-
 def test_rmw_patch_sets_film_sim_byte():
+    """rmw_patch writes the film-sim byte and leaves the rest intact."""
     base = bytes(OFFSET_FILM_SIM + 10)
     patched = rmw_patch(base, film_sim_byte=VELVIA_BYTE)
     assert patched[OFFSET_FILM_SIM] == VELVIA_BYTE
@@ -79,36 +86,39 @@ def test_rmw_patch_sets_film_sim_byte():
 
 
 def test_rmw_patch_does_not_mutate_input():
+    """rmw_patch returns a new buffer and never mutates the input."""
     base = bytes(OFFSET_FILM_SIM + 10)
     rmw_patch(base, film_sim_byte=ACROS_BYTE)
     assert base[OFFSET_FILM_SIM] == 0x00
 
 
 def test_rmw_patch_rejects_short_profile():
+    """rmw_patch rejects a profile too short to hold the offset."""
     with pytest.raises(ValueError, match="too short"):
         rmw_patch(bytes(10), film_sim_byte=VELVIA_BYTE)
 
 
-# --- film_simulation_byte / apply_recipe -----------------------------------
-
-
 def test_film_simulation_byte_known():
+    """Known film-simulation names map to their profile bytes."""
     assert film_simulation_byte("Velvia") == VELVIA_BYTE
     assert film_simulation_byte("Acros") == ACROS_BYTE
 
 
 def test_film_simulation_byte_unknown():
+    """An unknown film-simulation name raises ValueError."""
     with pytest.raises(ValueError, match="film simulation"):
         film_simulation_byte("Nope")
 
 
 def test_apply_recipe_patches_film_sim():
+    """apply_recipe patches the recipe's film simulation into the profile."""
     base = bytes(600)
     patched = apply_recipe(base, Recipe(film_simulation="Velvia"))
     assert patched[OFFSET_FILM_SIM] == VELVIA_BYTE
 
 
 def test_apply_recipe_rejects_size_quality_until_wired():
+    """Setting image_size/quality is rejected until those are wired up."""
     base = bytes(600)
     with pytest.raises(NotImplementedError, match="not wired up"):
         apply_recipe(base, Recipe(image_size="L"))
@@ -116,10 +126,8 @@ def test_apply_recipe_rejects_size_quality_until_wired():
         apply_recipe(base, Recipe(quality="FINE"))
 
 
-# --- CameraSession ---------------------------------------------------------
-
-
 def test_open_call_order():
+    """open() connects, sends the RAF, then reads the profile, in order."""
     cam = FakeCamera()
     session = session_for(cam)
     session.open("/tmp/shot.RAF")
@@ -133,6 +141,7 @@ def test_open_call_order():
 
 
 def test_render_does_not_resend_raf():
+    """render() applies the recipe without re-uploading the RAF."""
     cam = FakeCamera()
     session = session_for(cam)
     session.open("/tmp/shot.RAF")
@@ -149,6 +158,7 @@ def test_render_does_not_resend_raf():
 
 
 def test_render_passes_full_resolution_flag():
+    """render() forwards the full_resolution flag to the camera."""
     cam = FakeCamera()
     session = session_for(cam)
     session.open("/tmp/shot.RAF")
@@ -157,12 +167,14 @@ def test_render_passes_full_resolution_flag():
 
 
 def test_render_before_open_raises():
+    """Rendering before opening a RAF raises SessionStateError."""
     session = session_for(FakeCamera())
     with pytest.raises(SessionStateError):
         session.render(Recipe(), full_resolution=False)
 
 
 def test_connect_failure_raises_camera_error():
+    """A failed connect raises CameraError and leaves the session closed."""
     session = session_for(FakeCamera(connect_ok=False))
     with pytest.raises(CameraError):
         session.open("/tmp/shot.RAF")
@@ -170,6 +182,7 @@ def test_connect_failure_raises_camera_error():
 
 
 def test_foreign_raf_raises_and_cleans_up():
+    """A 0x2002 error becomes ForeignRafError and the camera disconnects."""
     cam = FakeCamera(fail_on="get_profile")
     session = session_for(cam)
     with pytest.raises(ForeignRafError):
@@ -179,6 +192,7 @@ def test_foreign_raf_raises_and_cleans_up():
 
 
 def test_close_is_idempotent_and_disconnects():
+    """close() disconnects once and is safe to call again."""
     cam = FakeCamera()
     session = session_for(cam)
     session.open("/tmp/shot.RAF")
@@ -189,6 +203,7 @@ def test_close_is_idempotent_and_disconnects():
 
 
 def test_context_manager_closes():
+    """Leaving the context manager closes the session."""
     cam = FakeCamera()
     with session_for(cam) as session:
         session.open("/tmp/shot.RAF")

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,135 @@
+"""Tests for the CameraWorker threading/coalescing layer."""
+
+import threading
+
+from grawji.preview import CameraWorker
+from grawji.recipe import Recipe
+
+
+def notify(event, sink=None):
+    """Callback that records the value (if a sink is given) and signals."""
+
+    def callback(value=None):
+        """Record the value (if a sink is given) and set the event."""
+        if sink is not None:
+            sink.append(value)
+        event.set()
+
+    return callback
+
+
+class FakeSession:
+    """A CameraSession stand-in; render can be gated to test ordering."""
+
+    def __init__(self):
+        """Start with empty logs and no gate or forced failure."""
+        self.opened = []
+        self.rendered = []
+        self.closed = False
+        self.gate = None  # optional Event to block inside render()
+        self.render_started = threading.Event()
+        self.fail_render = False
+
+    def open(self, raf_path):
+        """Record the opened RAF path."""
+        self.opened.append(raf_path)
+
+    def render(self, recipe, *, full_resolution):
+        """Signal start, optionally block on the gate, then record/return."""
+        self.render_started.set()
+        if self.gate is not None:
+            self.gate.wait(timeout=5)
+        if self.fail_render:
+            raise RuntimeError("render boom")
+        self.rendered.append((recipe.film_simulation, full_resolution))
+        return b"JPEG:" + recipe.film_simulation.encode()
+
+    def close(self):
+        """Mark the session as closed."""
+        self.closed = True
+
+
+def test_open_then_render_delivers_result():
+    """An open then a render run in order and deliver the JPEG result."""
+    sess = FakeSession()
+    results = []
+    done = threading.Event()
+
+    worker = CameraWorker(sess)
+    worker.start()
+    worker.open("/x.RAF")
+    worker.render(
+        Recipe(film_simulation="Velvia"),
+        full_resolution=False,
+        on_done=notify(done, results),
+    )
+    assert done.wait(timeout=5)
+    worker.stop()
+
+    assert sess.opened == ["/x.RAF"]  # open never coalesced away
+    assert sess.rendered == [("Velvia", False)]
+    assert results == [b"JPEG:Velvia"]
+    assert sess.closed  # stop() closed the session
+
+
+def test_render_coalesces_pending_render():
+    """A render queued behind a not-yet-started render replaces it."""
+    sess = FakeSession()
+    sess.gate = threading.Event()
+    done = threading.Event()
+    finished = []
+
+    worker = CameraWorker(sess)
+    worker.start()
+
+    worker.render(Recipe(film_simulation="Provia"), full_resolution=False)
+    assert sess.render_started.wait(timeout=5)
+
+    worker.render(Recipe(film_simulation="Velvia"), full_resolution=False)
+    worker.render(
+        Recipe(film_simulation="Acros"),
+        full_resolution=True,
+        on_done=notify(done, finished),
+    )
+
+    sess.gate.set()
+    assert done.wait(timeout=5)
+    worker.stop()
+
+    assert sess.rendered == [("Provia", False), ("Acros", True)]
+    assert finished == [b"JPEG:Acros"]
+
+
+def test_render_error_routed_to_on_error():
+    """A render exception is delivered to on_error, not swallowed."""
+    sess = FakeSession()
+    sess.fail_render = True
+    errors = []
+    done = threading.Event()
+
+    worker = CameraWorker(sess)
+    worker.start()
+    worker.render(
+        Recipe(),
+        full_resolution=False,
+        on_error=notify(done, errors),
+    )
+    assert done.wait(timeout=5)
+    worker.stop()
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], RuntimeError)
+    assert sess.rendered == []
+
+
+def test_context_manager_starts_and_closes():
+    """The context manager starts the worker and closes on exit."""
+    sess = FakeSession()
+    done = threading.Event()
+
+    with CameraWorker(sess) as worker:
+        worker.open("/y.RAF", on_done=notify(done))
+        assert done.wait(timeout=5)
+
+    assert sess.opened == ["/y.RAF"]
+    assert sess.closed  # __exit__ -> stop() -> close()

--- a/tests/test_raf.py
+++ b/tests/test_raf.py
@@ -1,0 +1,44 @@
+"""Tests for embedded-JPEG extraction from RAF bytes."""
+
+import struct
+
+import pytest
+
+from grawji.raf import RAF_MAGIC, embedded_jpeg_from_bytes
+
+_OFFSET = 96  # where we place the fake JPEG in the synthetic RAF
+
+
+def _make_raf(jpeg: bytes) -> bytes:
+    """Build a minimal synthetic RAF wrapping the given JPEG bytes."""
+    header = bytearray(_OFFSET)
+    header[: len(RAF_MAGIC)] = RAF_MAGIC
+    struct.pack_into(">I", header, 84, _OFFSET)
+    struct.pack_into(">I", header, 88, len(jpeg))
+    return bytes(header) + jpeg
+
+
+def test_extracts_embedded_jpeg():
+    """The embedded JPEG is sliced out using the header offset/length."""
+    jpeg = b"\xff\xd8" + b"fake-jpeg-payload" + b"\xff\xd9"
+    assert embedded_jpeg_from_bytes(_make_raf(jpeg)) == jpeg
+
+
+def test_rejects_non_raf():
+    """Bytes without the RAF magic are rejected."""
+    with pytest.raises(ValueError, match="bad magic"):
+        embedded_jpeg_from_bytes(b"NOT-A-RAF" + bytes(200))
+
+
+def test_rejects_short_header():
+    """A truncated header (no room for the offsets) is rejected."""
+    with pytest.raises(ValueError, match="too short"):
+        embedded_jpeg_from_bytes(RAF_MAGIC + b"\x00\x00")
+
+
+def test_rejects_missing_jpeg_marker():
+    """A region that does not start with the JPEG SOI is rejected."""
+    raf = bytearray(_make_raf(b"\xff\xd8\xff\xd9"))
+    raf[_OFFSET : _OFFSET + 2] = b"\x00\x00"  # corrupt the SOI marker
+    with pytest.raises(ValueError, match="no valid embedded"):
+        embedded_jpeg_from_bytes(bytes(raf))

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -4,6 +4,7 @@ from grawji.recipe import Recipe
 
 
 def test_defaults():
+    """A fresh recipe defaults to Provia and inherits size/quality."""
     recipe = Recipe()
     assert recipe.film_simulation == "Provia"
     assert recipe.image_size is None
@@ -11,10 +12,12 @@ def test_defaults():
 
 
 def test_roundtrip_dict():
+    """to_dict/from_dict round-trips a fully-populated recipe."""
     recipe = Recipe(film_simulation="Velvia", image_size="L", quality="FINE")
     assert Recipe.from_dict(recipe.to_dict()) == recipe
 
 
 def test_from_dict_ignores_unknown_keys():
+    """from_dict ignores keys that are not recipe fields."""
     recipe = Recipe.from_dict({"film_simulation": "Acros", "bogus": 1})
     assert recipe.film_simulation == "Acros"


### PR DESCRIPTION
- Introduced CameraWorker to offload camera operations to a background thread.
- Prevents UI freezing by dispatching results back to the GTK main thread.
- Enables coalescing of render requests to avoid piling up rapid tasks.
- Supports unit testing without a UI by injecting a custom `dispatch`.