### PR TITLE
feat(templates, ui): add issue templates and integrate report button

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Something broke or behaves wrongly.
+labels: ["bug"]
+body:
+  - type: input
+    id: model
+    attributes:
+      label: Camera body
+      placeholder: FUJIFILM X-T5 (or "no camera involved")
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How is grawji installed?
+      options:
+        - Flatpak
+        - From source
+    validations:
+      required: true
+  - type: checkboxes
+    id: mode
+    attributes:
+      label: Camera connection
+      options:
+        - label: >
+            The camera was in "USB RAW CONV./BACKUP RESTORE" mode
+            (SET UP - CONNECTION SETTING - USB MODE)
+        - label: The RAF files were shot by this same camera body
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened, and what did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open folder ...
+        2. Select image ...
+        3. ...
+  - type: textarea
+    id: log
+    attributes:
+      label: Log output
+      description: >
+        Run grawji from a terminal with `--verbose`
+        (`flatpak run io.github.p5k369.grawji --verbose` or
+        `python -m grawji --verbose`) and paste the output around the
+        failure.
+      render: text

--- a/.github/ISSUE_TEMPLATE/new-body-report.yml
+++ b/.github/ISSUE_TEMPLATE/new-body-report.yml
@@ -1,0 +1,59 @@
+name: Camera body report
+description: >
+  Report how grawji behaves with your camera body - especially if grawji
+  told you it is not in the capability table yet, or a control is missing
+  or has no effect.
+title: "[body] "
+labels: ["body-report"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thank you! grawji's per-body feature table is only as good as the
+        bodies people test it on. Every report here makes the table more trustworthy.
+  - type: input
+    id: model
+    attributes:
+      label: Camera body
+      description: Exactly as the camera reports it (shown in grawji's Info tab).
+      placeholder: FUJIFILM X-T5
+    validations:
+      required: true
+  - type: input
+    id: firmware
+    attributes:
+      label: Firmware version
+      description: SET UP menu, or hold DISP/BACK while powering on.
+      placeholder: "3.02"
+  - type: dropdown
+    id: outcome
+    attributes:
+      label: What happened?
+      options:
+        - grawji said my body is not in the capability table
+        - A control is shown but changing it does nothing in the render
+        - A control I expected is missing
+        - Everything works - consider this body confirmed
+        - Something else (describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: >
+        Which controls were shown or missing, and which had a visible
+        effect in the preview. For "does nothing": name the control and
+        the values you tried.
+    validations:
+      required: true
+  - type: textarea
+    id: verify_output
+    attributes:
+      label: verify_offsets.py output (optional, gold standard)
+      description: >
+        If you can run from a source checkout with your camera connected -
+        see CONTRIBUTING.md - paste the output of
+        `python scripts/verify_offsets.py YOUR.RAF` here. This is the
+        hardware proof that gets a body marked verified.
+      render: text

--- a/src/grawji/views/window.py
+++ b/src/grawji/views/window.py
@@ -421,7 +421,16 @@ class MainWindow(Adw.ApplicationWindow):
             "showing the safe baseline. Please report your body!"
         )
         toast.set_timeout(0)  # stays until dismissed, it is actionable
+        toast.set_button_label("Report…")
+        toast.connect("button-clicked", self._on_report_body)
         self.toast_overlay.add_toast(toast)
+
+    def _on_report_body(self, _toast: Any) -> None:
+        """Open the new-body issue template in the browser."""
+        Gtk.UriLauncher.new(
+            "https://github.com/p5k369/grawji/issues/new"
+            "?template=new-body-report.yml"
+        ).launch(self, None, None)
 
     def open_raf(self, path: str) -> None:
         """Open a RAF from outside (file manager or command line).


### PR DESCRIPTION
- Add dedicated issue templates for body reports and bug reports
- Open GitHub issue template directly in browser for easier reporting