### PR TITLE
feat(ui, persistence): add folder-tree expansion state and last image memory

### DIFF
--- a/src/grawji/settings.py
+++ b/src/grawji/settings.py
@@ -56,6 +56,10 @@ class Settings:
             preview.
         last_export_dir: Folder of the most recent export.
         the export dialogs open here. Empty means none.
+        expanded_folders: Folder-tree paths that were expanded, restored on
+            startup so the tree reopens as it was left.
+        last_image: Path of the image selected in the filmstrip, reselected
+            on startup when it is still present. Empty means none.
     """
 
     load_recipe_from_image: bool = True
@@ -72,6 +76,8 @@ class Settings:
     color_scheme: str = "default"
     show_histogram: bool = False
     last_export_dir: str = ""
+    expanded_folders: list[str] = field(default_factory=list)
+    last_image: str = ""
 
     def to_dict(self) -> dict[str, object]:
         """Return a plain dict for JSON storage."""

--- a/src/grawji/views/filmstrip.py
+++ b/src/grawji/views/filmstrip.py
@@ -114,6 +114,12 @@ class FilmStrip(Gtk.ScrolledWindow):
         self.set_child(self._box)
         self.set_min_content_height(thumb_height + 52)
 
+        scroll = Gtk.EventControllerScroll.new(
+            Gtk.EventControllerScrollFlags.BOTH_AXES
+        )
+        scroll.connect("scroll", self._on_scroll)
+        self.add_controller(scroll)
+
     def scan(self, folder: str) -> None:
         """Populate the strip with the RAF files in folder, and watch it.
 
@@ -351,6 +357,13 @@ class FilmStrip(Gtk.ScrolledWindow):
         adj = self.get_hadjustment()
         top = adj.get_upper() - adj.get_page_size()
         adj.set_value(max(adj.get_lower(), min(top, adj.get_value() + delta)))
+
+    def _on_scroll(self, _controller: Any, dx: float, dy: float) -> bool:
+        """Pan the strip sideways from a plain wheel or trackpad swipe."""
+        delta = dx or dy
+        if delta:
+            self._scroll_by(delta * self._card_width())
+        return True
 
     def _card_width(self) -> float:
         """Width of one thumbnail card including the strip spacing."""

--- a/src/grawji/views/foldertree.py
+++ b/src/grawji/views/foldertree.py
@@ -48,6 +48,7 @@ class FolderTree(Gtk.ScrolledWindow):
         on_select: Callable[[str], None],
         bookmarks: list[str] | None = None,
         on_bookmarks_changed: Callable[[list[str]], None] | None = None,
+        on_expansion_changed: Callable[[list[str]], None] | None = None,
     ) -> None:
         """Create the tree.
 
@@ -56,11 +57,17 @@ class FolderTree(Gtk.ScrolledWindow):
             bookmarks: Folder paths pinned above the filesystem roots.
             on_bookmarks_changed: Called with the new bookmark list after
                 the user adds or removes one, so it can be persisted.
+            on_expansion_changed: Called (debounced) with the expanded
+                folder paths whenever the tree structure changes, so the
+                expansion state can be persisted.
         """
         super().__init__()
         self._on_select = on_select
         self._bookmarks = list(bookmarks or [])
         self._on_bookmarks_changed = on_bookmarks_changed
+        self._on_expansion_changed = on_expansion_changed
+        self._restoring = False
+        self._save_pending = False
         self._launcher: Any = None
         self.add_css_class("folder-tree")
         self.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
@@ -87,6 +94,7 @@ class FolderTree(Gtk.ScrolledWindow):
             autoexpand=False,
             create_func=self._children_of,
         )
+        self._tree.connect("items-changed", self._on_tree_changed)
         self._selection = Gtk.SingleSelection(model=self._tree)
         self._selection.set_autoselect(False)
         self._selection.set_can_unselect(True)
@@ -138,6 +146,65 @@ class FolderTree(Gtk.ScrolledWindow):
             return False
         row.set_expanded(True)
         GLib.timeout_add(50, self._reveal_chain, chain, index + 1, 0)
+        return False
+
+    def expanded_folders(self) -> list[str]:
+        """Paths of every currently-expanded folder, shallowest first.
+
+        Only visible rows are walked, so the result is ancestor-closed:
+        a path is present only when all of its parents are expanded too.
+        """
+        out: list[str] = []
+        for i in range(self._tree.get_n_items()):
+            row = self._tree.get_item(i)
+            if row is None or not row.get_expanded():
+                continue
+            item = row.get_item()
+            path = item.file.get_path() if item is not None else None
+            if path:
+                out.append(path)
+        return out
+
+    def restore_expanded(self, paths: list[str]) -> None:
+        """Re-expand a saved set of folders (async, shallowest first)."""
+        ordered = sorted(set(paths), key=lambda p: len(Path(p).parts))
+        self._restoring = True
+        self._expand_next(ordered, 0, 0)
+
+    def _expand_next(self, paths: list[str], index: int, attempt: int) -> bool:
+        """Expand one saved folder, then schedule the next (async load)."""
+        if index >= len(paths):
+            self._restoring = False
+            return False
+        _position, row = self._find_row(Path(paths[index]))
+        if row is None:
+            if attempt < _REVEAL_MAX_ATTEMPTS:  # parent still loading
+                GLib.timeout_add(
+                    50, self._expand_next, paths, index, attempt + 1
+                )
+            else:  # not found, skip it and keep going
+                GLib.timeout_add(50, self._expand_next, paths, index + 1, 0)
+            return False
+        if row.is_expandable() and not row.get_expanded():
+            row.set_expanded(True)
+        GLib.timeout_add(50, self._expand_next, paths, index + 1, 0)
+        return False
+
+    def _on_tree_changed(self, *_a: Any) -> None:
+        """Persist the expansion set after the tree settles (debounced)."""
+        if self._restoring or self._on_expansion_changed is None:
+            return
+        if self._save_pending:
+            return
+        self._save_pending = True
+        GLib.timeout_add(400, self._flush_expansion)
+
+    def _flush_expansion(self) -> bool:
+        """Hand the current expansion set to the persistence callback."""
+        self._save_pending = False
+        if self._restoring or self._on_expansion_changed is None:
+            return False
+        self._on_expansion_changed(self.expanded_folders())
         return False
 
     def _on_row_activated(self, _list: Gtk.ListView, position: int) -> None:

--- a/src/grawji/views/recipe_manager.py
+++ b/src/grawji/views/recipe_manager.py
@@ -392,7 +392,7 @@ class RecipeLibraryController:
         recipe = self._library.get(name)
         if recipe is None:
             return
-        self._panel.set_recipe(recipe)
+        self._panel.set_active(recipe, name)
         self._on_render()
         self._on_status(f"Applied recipe “{name}”.")
 

--- a/src/grawji/views/window.py
+++ b/src/grawji/views/window.py
@@ -168,6 +168,7 @@ class MainWindow(Adw.ApplicationWindow):
             on_select=self._scan_folder,
             bookmarks=self._settings.bookmarks,
             on_bookmarks_changed=self._on_bookmarks_changed,
+            on_expansion_changed=self._on_expanded_changed,
         )
         self._foldertree.set_vexpand(True)
         self.foldertree_slot.append(self._foldertree)
@@ -204,10 +205,14 @@ class MainWindow(Adw.ApplicationWindow):
             _CAMERA_POLL_SECONDS, self._refresh_camera_status
         )
 
+        self._foldertree.restore_expanded(self._settings.expanded_folders)
         last = self._settings.last_folder
         if last and Path(last).is_dir():
             self._scan_folder(last)
             self._foldertree.reveal_path(last)
+            image = self._settings.last_image
+            if image and Path(image).is_file():
+                self._filmstrip.select_path(image)
 
     def _install_actions(self) -> None:
         """Install window actions used by the menu and keyboard shortcuts."""
@@ -343,6 +348,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._nav.update()
         self._generation += 1
         self._raf_path = Path(raf_path)
+        self._settings.last_image = raf_path
         self.set_title(f"grawji — {Path(raf_path).name}")
         self._set_busy(busy=True, status="Loading RAF…")
         if self._load_pending_id:
@@ -781,6 +787,11 @@ class MainWindow(Adw.ApplicationWindow):
     def _on_bookmarks_changed(self, bookmarks: list[str]) -> None:
         """Persist the folder-tree bookmarks."""
         self._settings.bookmarks = bookmarks
+        self._save_settings()
+
+    def _on_expanded_changed(self, paths: list[str]) -> None:
+        """Persist the folder-tree expansion state."""
+        self._settings.expanded_folders = paths
         self._save_settings()
 
     def _on_settings_changed(self) -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -46,6 +46,27 @@ def test_last_export_dir_defaults_empty():
     assert Settings().last_export_dir == ""
 
 
+def test_view_state_round_trip(tmp_path):
+    """Expanded folders and the last image survive a save/load round-trip."""
+    path = tmp_path / "settings.json"
+    save_settings(
+        Settings(
+            expanded_folders=["/photos", "/photos/raf"],
+            last_image="/photos/raf/DSCF0001.RAF",
+        ),
+        path,
+    )
+    loaded = load_settings(path)
+    assert loaded.expanded_folders == ["/photos", "/photos/raf"]
+    assert loaded.last_image == "/photos/raf/DSCF0001.RAF"
+
+
+def test_view_state_defaults_empty():
+    """View-state fields start empty so a fresh install restores nothing."""
+    assert Settings().expanded_folders == []
+    assert Settings().last_image == ""
+
+
 def test_unknown_keys_ignored(tmp_path):
     """Unknown keys in the file are ignored."""
     path = tmp_path / "settings.json"


### PR DESCRIPTION
- Persist expanded folder-tree state across sessions for improved navigation
- Restore last selected image in the filmstrip after application restart
- Introduce horizontal scroll handling in the filmstrip for smoother navigation