### PR TITLE
feat(tests): refactor RAF parsing and enhance JPEG extraction logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,21 +52,20 @@ render-many** workflow:
 
 ## Install
 
-Three ways to get grawji: the **[Flatpak](#flatpak)** (bundled, one command,
-for everyone), **[Nix](#nix)** (flake), or **[from source](#from-source)**.
-
 First, put the camera in RAW-conversion USB mode, otherwise it enumerates as
 a card reader and rawji cannot talk to it:
 
 > **Set Up** → **Connection Setting** → **USB Mode** → **USB RAW CONV./BACKUP RESTORE**
 
-### Flatpak
-
-Bundles everything (GTK4, libadwaita, the EXIF and USB stacks, rawji and
-grawji), only the shared GNOME runtime comes from the network.
+| How | Install | Notes                                                                                    |
+| --- | --- |------------------------------------------------------------------------------------------|
+| **Flatpak** | `flatpak install --user grawji.flatpak` | bundle from [Releases](https://github.com/p5k369/grawji/releases), everything included   |
+| **Nix** | `nix run github:p5k369/grawji` | flake, no clone needed. `nix build` gives `./result/bin/grawji`                          |
+| **Gentoo** | `emerge media-gfx/grawji` | in [GURU](https://wiki.gentoo.org/wiki/Project:GURU), `~amd64`, pulls `dev-python/rawji` |
+| **Source** | `make install` | system GTK4/PyGObject first, see below                                                   |
 
 <details>
-<summary><b>Step-by-step</b></summary>
+<summary><b>Flatpak, step-by-step</b></summary>
 
 **1. Set up Flatpak and Flathub** (most distros ship Flatpak):
 
@@ -91,26 +90,26 @@ flatpak run io.github.p5k369.grawji
 
 </details>
 
-### Nix
+<details>
+<summary><b>Gentoo, step-by-step</b></summary>
 
-The repo is a flake. With `nix` and flakes enabled, run it straight from
-GitHub, no clone required:
+Enable the overlay and accept the `~amd64` keywords once:
 
 ```sh
-nix run github:p5k369/grawji
+eselect repository enable guru
+emerge --sync guru
+echo "media-gfx/grawji ~amd64
+dev-python/rawji ~amd64" >> /etc/portage/package.accept_keywords/grawji
+emerge -av media-gfx/grawji
 ```
 
-`nix build github:p5k369/grawji` produces `./result/bin/grawji`. The flake
-exposes `packages.<system>.{grawji,rawji}`, so you can also add grawji as an
-input to your own flake.
+</details>
 
-### From source
+<details>
+<summary><b>From source, step-by-step</b></summary>
 
 GTK4 and PyGObject come from your distribution, not pip: install the system
 packages, then `make install`.
-
-<details>
-<summary><b>Step-by-step</b></summary>
 
 **1. System packages** (GTK4, libadwaita, PyGObject, the GExiv2 EXIF reader,
 and the USB stack). Names vary by distro:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ omit = [
   "**/__main__.py",
   "src/grawji/views/**",
   "src/grawji/ui/**",
+  "src/grawji/logsetup.py",
 ]
 
 [tool.coverage.report]

--- a/src/grawji/raf.py
+++ b/src/grawji/raf.py
@@ -15,9 +15,8 @@ _HEADER_MIN = _JPEG_LENGTH_POS + 4
 _JPEG_SOI = b"\xff\xd8"
 
 
-def _jpeg_extent(handle: BinaryIO) -> tuple[int, int]:
-    """Read a RAF header and return its embedded JPEG (offset, length)."""
-    header = handle.read(_HEADER_MIN)
+def _parse_extent(header: bytes) -> tuple[int, int]:
+    """Validate a RAF header and return its embedded JPEG (offset, length)."""
     if not header.startswith(RAF_MAGIC):
         msg = "not a Fujifilm RAF file (bad magic)"
         raise ValueError(msg)
@@ -31,6 +30,11 @@ def _jpeg_extent(handle: BinaryIO) -> tuple[int, int]:
         ">I", header[_JPEG_LENGTH_POS : _JPEG_LENGTH_POS + 4]
     )[0]
     return offset, length
+
+
+def _jpeg_extent(handle: BinaryIO) -> tuple[int, int]:
+    """Read a RAF header and return its embedded JPEG (offset, length)."""
+    return _parse_extent(handle.read(_HEADER_MIN))
 
 
 def embedded_jpeg(path: str | Path) -> bytes:
@@ -58,29 +62,8 @@ def embedded_jpeg_prefix(path: str | Path, max_bytes: int) -> bytes:
 
 
 def embedded_jpeg_from_bytes(data: bytes) -> bytes:
-    """Extract the embedded JPEG from raw RAF bytes.
-
-    Args:
-        data: The full contents of a RAF file.
-
-    Returns:
-        The embedded JPEG bytes.
-
-    Raises:
-        ValueError: If the bytes are not a RAF or hold no embedded JPEG.
-    """
-    if not data.startswith(RAF_MAGIC):
-        msg = "not a Fujifilm RAF file (bad magic)"
-        raise ValueError(msg)
-    if len(data) < _HEADER_MIN:
-        msg = "RAF header too short"
-        raise ValueError(msg)
-    offset = struct.unpack(
-        ">I", data[_JPEG_OFFSET_POS : _JPEG_OFFSET_POS + 4]
-    )[0]
-    length = struct.unpack(
-        ">I", data[_JPEG_LENGTH_POS : _JPEG_LENGTH_POS + 4]
-    )[0]
+    """Extract the embedded JPEG from raw RAF bytes."""
+    offset, length = _parse_extent(data)
     jpeg = data[offset : offset + length]
     if len(jpeg) != length or not jpeg.startswith(_JPEG_SOI):
         msg = "RAF has no valid embedded JPEG"

--- a/tests/test_camera_info.py
+++ b/tests/test_camera_info.py
@@ -1,6 +1,47 @@
-"""Tests for camera-error classification."""
+"""Tests for camera detection and camera-error classification."""
 
-from grawji.camera_info import is_camera_disconnected, is_camera_stuck
+import usb.core
+
+from grawji.camera_info import (
+    detect_camera,
+    is_camera_disconnected,
+    is_camera_stuck,
+)
+
+
+class _FakeDevice:
+    """Stand-in for a pyusb device carrying only the product id."""
+
+    def __init__(self, pid):
+        self.idProduct = pid
+
+
+def test_detects_known_body(monkeypatch):
+    """A known Fuji product id maps to its friendly name."""
+    monkeypatch.setattr(usb.core, "find", lambda **_: _FakeDevice(0x0313))
+    assert detect_camera() == "X-E5"
+
+
+def test_unknown_pid_gets_generic_label(monkeypatch):
+    """Any device on the Fuji vendor id is accepted, label is generic."""
+    monkeypatch.setattr(usb.core, "find", lambda **_: _FakeDevice(0xFFFF))
+    assert detect_camera() == "Camera"
+
+
+def test_no_device_means_none(monkeypatch):
+    """No device on the Fuji vendor id yields None."""
+    monkeypatch.setattr(usb.core, "find", lambda **_: None)
+    assert detect_camera() is None
+
+
+def test_usb_error_means_none(monkeypatch):
+    """A failing USB backend is reported as no camera, not an error."""
+
+    def _raise(**_):
+        raise usb.core.USBError("no backend available")
+
+    monkeypatch.setattr(usb.core, "find", _raise)
+    assert detect_camera() is None
 
 
 def test_stuck_on_timeout():

--- a/tests/test_raf.py
+++ b/tests/test_raf.py
@@ -1,10 +1,15 @@
-"""Tests for embedded-JPEG extraction from RAF bytes."""
+"""Tests for embedded-JPEG extraction from RAF bytes and files."""
 
 import struct
 
 import pytest
 
-from grawji.raf import RAF_MAGIC, embedded_jpeg_from_bytes
+from grawji.raf import (
+    RAF_MAGIC,
+    embedded_jpeg,
+    embedded_jpeg_from_bytes,
+    embedded_jpeg_prefix,
+)
 
 _OFFSET = 96  # where we place the fake JPEG in the synthetic RAF
 
@@ -42,3 +47,70 @@ def test_rejects_missing_jpeg_marker():
     raf[_OFFSET : _OFFSET + 2] = b"\x00\x00"  # corrupt the SOI marker
     with pytest.raises(ValueError, match="no valid embedded"):
         embedded_jpeg_from_bytes(bytes(raf))
+
+
+def _write_raf(tmp_path, jpeg: bytes):
+    """Write a synthetic RAF wrapping jpeg and return its path."""
+    path = tmp_path / "shot.RAF"
+    path.write_bytes(_make_raf(jpeg))
+    return path
+
+
+def test_reads_jpeg_from_file(tmp_path):
+    """The file path variant extracts the same JPEG as the bytes one."""
+    jpeg = b"\xff\xd8" + b"fake-jpeg-payload" + b"\xff\xd9"
+    assert embedded_jpeg(_write_raf(tmp_path, jpeg)) == jpeg
+
+
+def test_reads_jpeg_from_str_path(tmp_path):
+    """A plain string path is accepted as well."""
+    jpeg = b"\xff\xd8\xff\xd9"
+    assert embedded_jpeg(str(_write_raf(tmp_path, jpeg))) == jpeg
+
+
+def test_file_rejects_non_raf(tmp_path):
+    """A file without the RAF magic is rejected."""
+    path = tmp_path / "not.RAF"
+    path.write_bytes(b"NOT-A-RAF" + bytes(200))
+    with pytest.raises(ValueError, match="bad magic"):
+        embedded_jpeg(path)
+
+
+def test_file_rejects_short_header(tmp_path):
+    """A truncated file (no room for the offsets) is rejected."""
+    path = tmp_path / "short.RAF"
+    path.write_bytes(RAF_MAGIC + b"\x00\x00")
+    with pytest.raises(ValueError, match="too short"):
+        embedded_jpeg(path)
+
+
+def test_file_rejects_truncated_jpeg(tmp_path):
+    """A length field pointing past the end of the file is rejected."""
+    data = bytearray(_make_raf(b"\xff\xd8\xff\xd9"))
+    struct.pack_into(">I", data, 88, 4 + 10)  # claim more than is there
+    path = tmp_path / "trunc.RAF"
+    path.write_bytes(bytes(data))
+    with pytest.raises(ValueError, match="no valid embedded"):
+        embedded_jpeg(path)
+
+
+def test_prefix_caps_the_read(tmp_path):
+    """The prefix variant returns at most max_bytes of the JPEG."""
+    jpeg = b"\xff\xd8" + b"x" * 100
+    assert embedded_jpeg_prefix(_write_raf(tmp_path, jpeg), 10) == jpeg[:10]
+
+
+def test_prefix_returns_whole_short_jpeg(tmp_path):
+    """A JPEG shorter than max_bytes comes back complete."""
+    jpeg = b"\xff\xd8\xff\xd9"
+    assert embedded_jpeg_prefix(_write_raf(tmp_path, jpeg), 1024) == jpeg
+
+
+def test_prefix_rejects_missing_jpeg_marker(tmp_path):
+    """The prefix variant still validates the SOI marker."""
+    data = bytearray(_make_raf(b"\xff\xd8\xff\xd9"))
+    data[_OFFSET : _OFFSET + 2] = b"\x00\x00"  # corrupt the SOI marker
+    path = tmp_path / "bad.RAF"
+    path.write_bytes(bytes(data))
+    with pytest.raises(ValueError, match="no valid embedded"):
+        embedded_jpeg_prefix(path, 10)


### PR DESCRIPTION
- Refactor _jpeg_extent and introduce _parse_extent for cleaner header parsing
- Improve test coverage for RAF file-based embedded JPEG extraction
- Add new tests for path-based extraction, truncated files, and invalid files