### PR TITLE
feat(ui, core): add FS dial support for compatible camera models

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         args: [ --branch, main ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         name: ruff

--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ export.
   parameters it supports. Effects it does not model are left neutral.
 - **Filmstrip** browser with EXIF info for the selected RAF.
 - **Export** single images or batch-export a whole folder at full resolution.
-- **Experimental**: write recipes into the camera's C1-C7 preset banks over
-  USB. Verified on the X100F and X-T3. X-Pro2, X-T2, X-T20, X-E3 and X-T30
-  should share the layout. Newer bodies are refused, their settings blob is
-  not mapped yet.
+- **Experimental**: write recipes into the camera's C1-C7 custom banks
+  over USB, on X-Processor 5 bodies and on the X100F/X-T3 generation, and
+  into the X-E5's FS1-FS3 film-simulation dial positions. Verified on
+  X-Processor 5 and X100F/X-T3 hardware. Every write is read back and
+  checked. Values a body cannot store are reported as dropped instead of
+  written wrong.
 - Keyboard shortcuts, pan/zoom with a darktable-style background, and a
   remembered window size and last folder.
 

--- a/src/grawji/camera_backup.py
+++ b/src/grawji/camera_backup.py
@@ -12,6 +12,11 @@ The layout is chosen from the model string in the blob header,
 which is authoritative because the blob came from the connected body. The
 blob_size guard in backup_recipe rejects a relative whose blob is not the
 expected size before anything is written.
+
+Gen5 bodies take a different route: they expose the C1-C7
+presets as plain PTP device properties, so when the connected body
+advertises the preset-slot property 0xD18C the transfer dispatches to
+grawji.camera_presets instead of patching the settings blob.
 """
 
 from __future__ import annotations
@@ -22,9 +27,9 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
 
+from grawji import camera_presets, fs_recipe
 from grawji.backup_recipe import (
     BackupWriteError,
-    BankLayout,
     apply_checksum,
     layout_for,
     read_names,
@@ -32,6 +37,7 @@ from grawji.backup_recipe import (
     write_name,
     write_recipes,
 )
+from grawji.camera_types import BackupTransferError, Camera, TransferResult
 from grawji.recipe import Recipe
 
 _log = logging.getLogger(__name__)
@@ -56,45 +62,6 @@ _OBJECTINFO_SIZE = 1076
 _MODEL_OFFSET = 0x14
 _SERIAL_OFFSET = 0x34
 _MAGIC = b"FUJIFILM"
-
-
-class Camera(Protocol):
-    """The subset of the rawji camera object this module uses."""
-
-    def send_command(
-        self, code: int, params: list[int] | None = ...
-    ) -> tuple[int, list[int], bytes]:
-        """Issue a PTP command; return (response code, params, data)."""
-        ...
-
-    def send_data_command(
-        self, code: int, params: list[int], data: bytes
-    ) -> tuple[int, list[int]]:
-        """Issue a PTP command with a data phase; return (code, params)."""
-        ...
-
-
-class BackupTransferError(RuntimeError):
-    """A backup transfer failed (unsupported body, PTP error, or no-op)."""
-
-
-@dataclass(frozen=True)
-class TransferResult:
-    """Outcome of a recipe transfer.
-
-    Attributes:
-        model: The body model parsed from the blob.
-        slots: The bank indices written.
-        applied: Count of intended recipe bytes confirmed on the camera.
-        maintained: Offsets the camera rewrote itself (checksum, counters).
-        dropped: Recipe features the body could not store, per slot.
-    """
-
-    model: str
-    slots: tuple[int, ...]
-    applied: int
-    maintained: tuple[int, ...]
-    dropped: dict[int, list[str]]
 
 
 def model_from_blob(blob: bytes) -> str | None:
@@ -125,11 +92,55 @@ def _check(code: int, what: str) -> None:
         raise BackupTransferError(f"{what} failed: 0x{code:04x}")
 
 
-def setup(cam: Camera) -> None:
+@dataclass(frozen=True)
+class DeviceInfo:
+    """What the camera's DeviceInfo advertises, as far as we parse it."""
+
+    model: str | None = None
+    props: frozenset[int] = frozenset()
+
+
+def _read_ptp_string(data: bytes, off: int) -> tuple[str, int]:
+    """Decode a PTP string at off."""
+    count = data[off]
+    off += 1
+    raw = data[off : off + count * 2]
+    return raw.decode("utf-16-le", "replace").rstrip("\x00"), off + count * 2
+
+
+def _read_u16_array(data: bytes, off: int) -> tuple[list[int], int]:
+    """Decode a PTP u16 array at off."""
+    (count,) = struct.unpack_from("<I", data, off)
+    off += 4
+    values = list(struct.unpack_from(f"<{count}H", data, off))
+    return values, off + count * 2
+
+
+def parse_device_info(data: bytes) -> DeviceInfo:
+    """Parse the model and advertised properties from a DeviceInfo."""
+    try:
+        # StandardVersion, VendorExtensionID, VendorExtensionVersion.
+        off = 2 + 4 + 2
+        _desc, off = _read_ptp_string(data, off)
+        off += 2  # FunctionalMode
+        _ops, off = _read_u16_array(data, off)
+        _events, off = _read_u16_array(data, off)
+        props, off = _read_u16_array(data, off)
+        for _ in range(2):  # CaptureFormats, ImageFormats
+            _fmt, off = _read_u16_array(data, off)
+        _manufacturer, off = _read_ptp_string(data, off)
+        model, off = _read_ptp_string(data, off)
+        return DeviceInfo(model=model or None, props=frozenset(props))
+    except (IndexError, struct.error):
+        return DeviceInfo()
+
+
+def setup(cam: Camera) -> DeviceInfo:
     """Run the preamble the camera requires before object access."""
-    code, _p, _d = cam.send_command(_GET_DEVICE_INFO)
+    code, _p, data = cam.send_command(_GET_DEVICE_INFO)
     _check(code, "GetDeviceInfo")
     cam.send_command(_GET_DEVICE_PROP_VALUE, [_USB_MODE_PROP])
+    return parse_device_info(data)
 
 
 def read_backup(cam: Camera) -> bytes:
@@ -151,8 +162,17 @@ def restore_backup(cam: Camera, blob: bytes) -> None:
     _check(code, "SendObject")
 
 
+class _HasVolatile(Protocol):
+    """Anything carrying the offsets the camera rewrites on a restore."""
+
+    @property
+    def volatile_offsets(self) -> frozenset[int]:
+        """Blob offsets the camera maintains itself."""
+        ...
+
+
 def classify_readback(
-    before: bytes, after: bytes, target: bytes, layout: BankLayout
+    before: bytes, after: bytes, target: bytes, layout: _HasVolatile
 ) -> tuple[list[int], list[int], list[int]]:
     """Classify how a written blob came back from the camera."""
     limit = min(len(before), len(target), len(after))
@@ -195,7 +215,14 @@ def read_bank_names(
     run_setup: bool = True,
 ) -> list[str]:
     """Return the connected body's current bank names, or [] if none."""
-    before = _read_once(connect, disconnect, run_setup)
+    cam = connect()
+    try:
+        info = setup(cam) if run_setup else DeviceInfo()
+        if camera_presets.supports_presets(info.props):
+            return camera_presets.read_preset_names(cam)
+        before = read_backup(cam)
+    finally:
+        disconnect(cam)
     layout = layout_for(model_from_blob(before))
     if layout is None:
         return []
@@ -212,9 +239,11 @@ def transfer_recipes(
 ) -> TransferResult:
     """Write recipes (and optional names) into the camera's custom banks.
 
-    Each phase opens its OWN connection: the camera rejects a GetObject
-    and a SendObject in one session with 0x200f, so download, restore and
-    read-back must be separate connects.
+    A gen5 body (preset properties advertised) is written over its first
+    connection and returns early. On the blob path each phase opens its
+    own connection: the camera rejects a GetObject and a SendObject in
+    one session with 0x200f, so download, restore and read-back must be
+    separate connects.
 
     Args:
         connect: Returns a freshly connected camera.
@@ -234,7 +263,16 @@ def transfer_recipes(
     if not assignments and not names:
         raise BackupTransferError("no bank assignments to write")
 
-    before = _read_once(connect, disconnect, run_setup)
+    cam = connect()
+    try:
+        info = setup(cam) if run_setup else DeviceInfo()
+        if camera_presets.supports_presets(info.props):
+            return camera_presets.transfer_presets(
+                cam, assignments, names=names, model=info.model
+            )
+        before = read_backup(cam)
+    finally:
+        disconnect(cam)
     model = model_from_blob(before)
     layout = layout_for(model)
     _log.debug("backup: model=%r blob=%d bytes", model, len(before))
@@ -306,17 +344,98 @@ def transfer_recipes(
     )
 
 
+def transfer_fs_recipes(
+    connect: Callable[[], Camera],
+    disconnect: Callable[[Camera], None],
+    assignments: dict[int, Recipe],
+    *,
+    run_setup: bool = True,
+) -> TransferResult:
+    """Write recipes into the body's FS1-FSn film-sim dial positions.
+
+    These positions are NOT reachable over the gen5 preset properties
+    (the slot selector refuses anything past C7), so they go through the
+    settings-blob restore path even on gen5 bodies, using fs_recipe's
+    verified per-parameter-array offsets. Each phase opens its own
+    connection, like the C1-C7 blob path.
+
+    Args:
+        connect: Returns a freshly connected camera.
+        disconnect: Tears a camera down.
+        assignments: FS index (0-based, FS1=0) -> recipe to store there.
+        run_setup: Run the PTP preamble first.
+
+    Raises:
+        BackupTransferError: On an unmapped body, a PTP error, or a
+            silently ignored write.
+        BackupWriteError: On a slot or blob-size mismatch.
+    """
+    if not assignments:
+        raise BackupTransferError("no FS assignments to write")
+
+    before = _read_once(connect, disconnect, run_setup)
+    model = model_from_blob(before)
+    layout = fs_recipe.layout_for(model)
+    if layout is None:
+        raise BackupTransferError(
+            f"body {model!r} has no mapped FS dial layout; refusing to write"
+        )
+
+    dropped = {
+        slot: fs_recipe.unsupported_fields(layout, recipe)
+        for slot, recipe in assignments.items()
+    }
+    dropped = {slot: fields for slot, fields in dropped.items() if fields}
+    if dropped:
+        _log.info("fs: dropping unsupported features %s", dropped)
+
+    target = fs_recipe.write_fs_recipes(before, layout, assignments)
+
+    cam = connect()
+    try:
+        if run_setup:
+            setup(cam)
+        restore_backup(cam, target)
+    except BackupTransferError as exc:
+        raise BackupTransferError(
+            f"{exc} [model {model}, FS write, {len(target)} bytes]"
+        ) from exc
+    finally:
+        disconnect(cam)
+
+    after = _read_once(connect, disconnect, run_setup)
+    applied, ignored, maintained = classify_readback(
+        before, after, target, layout
+    )
+    if ignored:
+        preview = ", ".join(f"@{o}" for o in ignored[:8])
+        raise BackupTransferError(
+            f"camera ACKed but silently ignored {len(ignored)} byte(s) "
+            f"({preview}); FS settings not fully written"
+        )
+    return TransferResult(
+        model=model or "",
+        slots=tuple(sorted(assignments)),
+        applied=len(applied),
+        maintained=tuple(maintained),
+        dropped=dropped,
+    )
+
+
 __all__ = [
     # BackupWriteError re-exported so callers catch both failure modes here.
     "BackupTransferError",
     "BackupWriteError",
     "Camera",
+    "DeviceInfo",
     "TransferResult",
     "classify_readback",
     "model_from_blob",
+    "parse_device_info",
     "read_backup",
     "read_bank_names",
     "restore_backup",
     "setup",
+    "transfer_fs_recipes",
     "transfer_recipes",
 ]

--- a/src/grawji/camera_presets.py
+++ b/src/grawji/camera_presets.py
@@ -1,0 +1,298 @@
+"""Transfer grawji recipes into gen5 custom presets over USB.
+
+XProcessor5 bodies expose the C1-C7 custom settings as PTP device
+properties (see grawji.preset_recipe), so writing a recipe is a plain
+SetDevicePropValue sequence on one connection: select the slot via
+0xD18C, write the name and the recipe properties in the X RAW Studio
+order, then read everything back to verify. There is no checksum and no
+object transfer, unlike the gen3/gen4 settings-blob path in
+grawji.camera_backup, which dispatches here when the connected body
+advertises the preset-slot property.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+import time
+
+from grawji.camera_types import (
+    BackupTransferError,
+    Camera,
+    TransferResult,
+)
+from grawji.preset_recipe import (
+    NUM_SLOTS,
+    PASSTHROUGH_DEFAULTS,
+    PROP_CLARITY,
+    PROP_PRESET_NAME,
+    PROP_PRESET_SLOT,
+    PROP_WB_COLOR_TEMP,
+    PROP_WB_SHIFT_B,
+    PROP_WB_SHIFT_R,
+    PROP_WHITE_BALANCE,
+    encode_recipe,
+    readback_matches,
+    unsupported_fields,
+)
+from grawji.recipe import Recipe
+
+_log = logging.getLogger(__name__)
+
+_GET_DEVICE_PROP_VALUE = 0x1015
+_SET_DEVICE_PROP_VALUE = 0x1016
+_PTP_OK = 0x2001
+
+_SLOT_SWITCH_DELAY_S = 0.1
+_NAME_MAX = 25
+
+# Properties read per slot before writing: the passthrough values plus
+# the WB cluster an "AsShot" recipe echoes back.
+_BASE_PROPS = (
+    *PASSTHROUGH_DEFAULTS,
+    PROP_WHITE_BALANCE,
+    PROP_WB_COLOR_TEMP,
+    PROP_WB_SHIFT_R,
+    PROP_WB_SHIFT_B,
+)
+
+# A property value read may come back as a u32 or a bare u16.
+_U32_SIZE = 4
+_U16_SIZE = 2
+
+
+def supports_presets(props: frozenset[int]) -> bool:
+    """Whether a body's advertised properties include the preset slot."""
+    return PROP_PRESET_SLOT in props
+
+
+def _get_prop(cam: Camera, prop: int) -> int | None:
+    """Read a device property's numeric value, or None if unreadable."""
+    code, _p, data = cam.send_command(_GET_DEVICE_PROP_VALUE, [prop])
+    if code != _PTP_OK or not data:
+        return None
+    if len(data) >= _U32_SIZE:
+        return int(struct.unpack_from("<I", data)[0]) & 0xFFFF
+    if len(data) >= _U16_SIZE:
+        return int(struct.unpack_from("<H", data)[0])
+    return data[0]
+
+
+def _set_prop(cam: Camera, prop: int, value: int) -> int:
+    """Write a u16 device property."""
+    return _set_prop_data(cam, prop, struct.pack("<H", value))
+
+
+def _set_prop_data(cam: Camera, prop: int, data: bytes) -> int:
+    """Write a raw property dataset."""
+    code, _p = cam.send_data_command(_SET_DEVICE_PROP_VALUE, [prop], data)
+    return code
+
+
+def _decode_ptp_string(data: bytes) -> str:
+    """Decode a PTP string dataset."""
+    if not data:
+        return ""
+    count = data[0]
+    raw = data[1 : 1 + count * 2]
+    return raw.decode("utf-16-le", "replace").rstrip("\x00")
+
+
+def _encode_ptp_string(text: str) -> bytes:
+    """Encode a PTP string dataset."""
+    if not text:
+        return b"\x00"
+    encoded = (text + "\x00").encode("utf-16-le")
+    return bytes([len(encoded) // 2]) + encoded
+
+
+def _select_slot(cam: Camera, slot: int) -> None:
+    """Make bank slot (0-based) the camera's active preset."""
+    code = _set_prop(cam, PROP_PRESET_SLOT, slot + 1)
+    if code != _PTP_OK:
+        raise BackupTransferError(
+            f"could not select bank C{slot + 1}: 0x{code:04x}"
+        )
+    time.sleep(_SLOT_SWITCH_DELAY_S)
+
+
+def _read_name(cam: Camera) -> str:
+    """The active slot's name, or "" if unreadable."""
+    code, _p, data = cam.send_command(
+        _GET_DEVICE_PROP_VALUE, [PROP_PRESET_NAME]
+    )
+    if code != _PTP_OK:
+        return ""
+    return _decode_ptp_string(data).strip()
+
+
+def _active_slot(cam: Camera) -> int | None:
+    """The camera's current active slot (0-based), or None."""
+    raw = _get_prop(cam, PROP_PRESET_SLOT)
+    if raw is None or not 1 <= raw <= NUM_SLOTS:
+        return None
+    return raw - 1
+
+
+def _restore_slot(cam: Camera, slot: int | None) -> None:
+    """Put the camera back on the slot the user had active."""
+    if slot is None:
+        return
+    if _set_prop(cam, PROP_PRESET_SLOT, slot + 1) != _PTP_OK:
+        _log.debug("presets: could not restore the active slot")
+
+
+def read_preset_names(cam: Camera) -> list[str]:
+    """Return the current names of all bank slots.
+
+    Selecting each slot to read its name changes the camera's active
+    preset, so the original selection is restored afterwards.
+    """
+    original = _active_slot(cam)
+    names = []
+    try:
+        for slot in range(NUM_SLOTS):
+            _select_slot(cam, slot)
+            names.append(_read_name(cam))
+    finally:
+        _restore_slot(cam, original)
+    return names
+
+
+def _write_name(cam: Camera, name: str) -> tuple[int, list[str]]:
+    """Write the active slot's name; return (applied, problem notes)."""
+    code = _set_prop_data(cam, PROP_PRESET_NAME, _encode_ptp_string(name))
+    if code != _PTP_OK:
+        return 0, [f"name not accepted (0x{code:04x})"]
+    stored = _read_name(cam)
+    if stored == name:
+        return 1, []
+    return 0, [f"name stored as {stored!r}"]
+
+
+def _write_slot(
+    cam: Camera, slot: int, recipe: Recipe | None, name: str | None
+) -> tuple[int, list[str]]:
+    """Write one slot."""
+    applied = 0
+    notes = []
+
+    if name is not None:
+        count, name_notes = _write_name(cam, name)
+        applied += count
+        notes.extend(name_notes)
+
+    if recipe is None:
+        return applied, notes
+
+    base = {}
+    for prop in _BASE_PROPS:
+        value = _get_prop(cam, prop)
+        if value is not None:
+            base[prop] = value
+
+    ignored = []
+    for prop, value in encode_recipe(recipe, base):
+        code = _set_prop(cam, prop, value)
+        read_back = _get_prop(cam, prop)
+        if read_back is None and code == _PTP_OK:
+            # ACKed but unverifiable, trust the ACK rather than fail.
+            applied += 1
+        elif read_back is not None and readback_matches(
+            prop, value, read_back
+        ):
+            applied += 1
+            if code != _PTP_OK:
+                _log.debug(
+                    "presets: 0x%04x rejected 0x%04x but already holds it",
+                    prop,
+                    value,
+                )
+        elif code != _PTP_OK and prop == PROP_CLARITY:
+            notes.append("clarity (set it on the camera and resave)")
+        elif code != _PTP_OK:
+            raise BackupTransferError(
+                f"camera rejected property 0x{prop:04x}=0x{value:04x} "
+                f"on bank C{slot + 1} (0x{code:04x})"
+            )
+        else:
+            ignored.append(prop)
+
+    if ignored:
+        preview = ", ".join(f"0x{p:04x}" for p in ignored[:8])
+        raise BackupTransferError(
+            f"camera ACKed but silently ignored {len(ignored)} propert"
+            f"{'y' if len(ignored) == 1 else 'ies'} on bank C{slot + 1} "
+            f"({preview}); settings not fully written"
+        )
+    return applied, notes
+
+
+def transfer_presets(
+    cam: Camera,
+    assignments: dict[int, Recipe],
+    *,
+    names: dict[int, str] | None = None,
+    model: str | None = None,
+) -> TransferResult:
+    """Write recipes (and optional names) into the camera's presets.
+
+    Args:
+        cam: A connected camera whose body advertises the preset
+            properties (see supports_presets).
+        assignments: Bank index (0-based) -> recipe to store there.
+        names: Optional bank index -> new name (truncated to fit).
+        model: The body model, for the result.
+
+    Returns:
+        A TransferResult; maintained is unused on this path and dropped
+        carries both unsupported recipe features and camera-side notes.
+
+    Raises:
+        BackupTransferError: On a PTP error or a silently ignored write.
+    """
+    names = names or {}
+    if not assignments and not names:
+        raise BackupTransferError("no bank assignments to write")
+
+    slots = sorted(set(assignments) | set(names))
+    bad = [s for s in slots if not 0 <= s < NUM_SLOTS]
+    if bad:
+        raise BackupTransferError(f"bank slot out of range: {bad}")
+
+    dropped: dict[int, list[str]] = {}
+    applied = 0
+    original = _active_slot(cam)
+    try:
+        for slot in slots:
+            _select_slot(cam, slot)
+            recipe = assignments.get(slot)
+            name = names.get(slot)
+            if name is not None:
+                name = name[:_NAME_MAX]
+            notes = unsupported_fields(recipe) if recipe else []
+            count, slot_notes = _write_slot(cam, slot, recipe, name)
+            applied += count
+            notes.extend(slot_notes)
+            if notes:
+                dropped[slot] = notes
+    finally:
+        _restore_slot(cam, original)
+
+    _log.debug(
+        "presets: wrote %d slots, %d properties confirmed", len(slots), applied
+    )
+    return TransferResult(
+        model=model or "",
+        slots=tuple(slots),
+        applied=applied,
+        maintained=(),
+        dropped=dropped,
+    )
+
+
+__all__ = [
+    "read_preset_names",
+    "supports_presets",
+    "transfer_presets",
+]

--- a/src/grawji/camera_types.py
+++ b/src/grawji/camera_types.py
@@ -1,0 +1,45 @@
+"""Shared types for the camera transfer modules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class Camera(Protocol):
+    """The subset of the rawji camera object the transfer modules use."""
+
+    def send_command(
+        self, code: int, params: list[int] | None = ...
+    ) -> tuple[int, list[int], bytes]:
+        """Issue a PTP command."""
+        ...
+
+    def send_data_command(
+        self, code: int, params: list[int], data: bytes
+    ) -> tuple[int, list[int]]:
+        """Issue a PTP command with a data phase."""
+        ...
+
+
+class BackupTransferError(RuntimeError):
+    """A backup transfer failed (unsupported body, PTP error, or no-op)."""
+
+
+@dataclass(frozen=True)
+class TransferResult:
+    """Outcome of a recipe transfer.
+
+    Attributes:
+        model: The body model parsed from the blob or DeviceInfo.
+        slots: The bank indices written.
+        applied: Count of intended recipe values confirmed on the camera.
+        maintained: Offsets the camera rewrote itself (checksum, counters).
+        dropped: Recipe features the body could not store, per slot.
+    """
+
+    model: str
+    slots: tuple[int, ...]
+    applied: int
+    maintained: tuple[int, ...]
+    dropped: dict[int, list[str]]

--- a/src/grawji/core.py
+++ b/src/grawji/core.py
@@ -565,6 +565,16 @@ class CameraSession:
                 names=names,
             )
 
+    def transfer_fs_recipes(self, assignments: dict[int, Recipe]) -> Any:
+        """Write recipes into the body's FS1-FSn dial positions over USB."""
+        with self._lock:
+            self._close_locked()
+            return camera_backup.transfer_fs_recipes(
+                self._connect_backup,
+                self._safe_disconnect,
+                assignments,
+            )
+
     def read_bank_names(self) -> list[str]:
         """Return the connected body's current bank names, or [] if none."""
         with self._lock:

--- a/src/grawji/fs_recipe.py
+++ b/src/grawji/fs_recipe.py
@@ -1,0 +1,291 @@
+"""Write a Recipe into a body's FS1-FSn film-sim dial presets.
+
+Some bodies (the X-E5 is the first mapped one) have a film simulation
+dial whose FS positions store a full per-position recipe. Those
+positions are not exposed through the gen5 preset properties (the slot
+selector 0xD18C rejects anything past C7), so they are written through
+the settings-blob restore path instead.
+
+Unlike the C1-C7 bank records of backup_recipe, the FS recipe is stored
+as parallel per-parameter arrays: for each parameter the FS1..FSn
+values are adjacent elements, so a field is addressed as its FS1 offset
+plus the slot index (times the element size).
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+
+from grawji.backup_recipe import BackupWriteError
+from grawji.recipe import Recipe
+
+# The X-E5 whole-file checksum: additive u16 little-endian at 0x120.
+# A patch inside the covered payload delta-updates the stored value
+# (hardware-verified on every controlled diff round: the stored u16
+# moved by exactly the content byte delta).
+_CHECKSUM_OFFSET = 0x120
+
+# X-E5 FS-dial film-sim codes, all hardware verified.
+_FS_FILM_SIMS = {
+    "Provia": 0x01,
+    "Astia": 0x02,
+    "Velvia": 0x04,
+    "Sepia": 0x06,
+    "Monochrome": 0x09,
+    "MonochromeR": 0x0A,
+    "MonochromeYe": 0x0B,
+    "MonochromeG": 0x0C,
+    "ProNegStd": 0x0D,
+    "ProNegHi": 0x0E,
+    "ClassicChrome": 0x0F,
+    "ClassicNeg": 0x10,
+    "NostalgicNeg": 0x11,
+    "RealaAce": 0x12,
+    "Eterna": 0x13,
+    "EternaBleach": 0x14,
+    "Acros": 0x16,
+    "AcrosR": 0x17,
+    "AcrosYe": 0x18,
+    "AcrosG": 0x19,
+}
+
+# WB-mode codes of the blob preamble
+_WB_CODES = {
+    "Auto": 0x00,
+    "Daylight": 0x03,
+    "Shade": 0x04,
+    "Fluorescent1": 0x05,
+    "Fluorescent2": 0x06,
+    "Fluorescent3": 0x07,
+    "Incandescent": 0x08,
+    "Underwater": 0x09,
+    "Temperature": 0x0A,
+}
+
+# DR codes: Auto=0, DR100=1, DR200=2 hardware-measured on the X-E5
+_DR_CODES = {"DR100": 1, "DR200": 2, "DR400": 3}
+
+_CHROME_CODES = {"Off": 0, "Weak": 1, "Strong": 2}
+_GRAIN_ROUGH_CODES = {"Strong": 0, "Weak": 1, "Off": 2}
+_GRAIN_SIZE_CODES = {"Small": 0, "Large": 1}
+
+# Monochromatic Color toning (B&W sims only). Encoded raw = 18 - value,
+# neutral 18, like the other descending FS-array codes. Hardware-verified
+# on the X-E5
+_MONO_TONING_PREFIXES = ("Acros", "Monochrome")
+_MONO_NEUTRAL = 18
+_MONO_LIMIT = 18
+
+# A u16 kelvin field occupies two blob bytes, everything else is a byte.
+_U16_SIZE = 2
+_BYTE_MAX = 0xFF
+
+
+def _mono_code(value: int) -> int:
+    """Encode a mono toning axis: raw = 18 - value, clamped to +-18."""
+    clamped = max(-_MONO_LIMIT, min(_MONO_LIMIT, value))
+    return _MONO_NEUTRAL - clamped
+
+
+@dataclass(frozen=True)
+class FsField:
+    """One parameter array: FS1's offset and the per-slot element size."""
+
+    offset: int
+    step: int = 1
+
+
+@dataclass(frozen=True)
+class FsLayout:
+    """Where one body stores its FS dial-preset parameter arrays.
+
+    Attributes:
+        blob_size: Expected total blob length, a sanity guard.
+        num_slots: Number of FS dial positions.
+        fields: Parameter name -> its FS1 offset and slot stride.
+        volatile_offsets: Blob offsets the camera rewrites itself on a
+            restore (the checksum field).
+    """
+
+    blob_size: int
+    num_slots: int
+    fields: dict[str, FsField]
+    volatile_offsets: frozenset[int] = frozenset(
+        {_CHECKSUM_OFFSET, _CHECKSUM_OFFSET + 1}
+    )
+
+
+_XE5 = FsLayout(
+    blob_size=70524,
+    num_slots=3,
+    fields={
+        "film_sim": FsField(1991, step=3),
+        "wb_kelvin": FsField(34704, step=2),
+        "wb_mode": FsField(34716),
+        "nr": FsField(34722),
+        "clarity": FsField(34728),
+        "mono_wc": FsField(34731),
+        "mono_mg": FsField(34737),
+        "dr": FsField(34743),
+        "color": FsField(34752),
+        "sharpness": FsField(34758),
+        "highlight": FsField(34764),
+        "shadow": FsField(34770),
+        "color_chrome": FsField(34776),
+        "color_chrome_blue": FsField(34779),
+        "grain_rough": FsField(34782),
+        "grain_size": FsField(34785),
+        "smooth_skin": FsField(34788),
+        "wb_shift_r": FsField(34864),
+        "wb_shift_b": FsField(34870),
+    },
+)
+
+# EXIF/DeviceInfo model (normalized like backup_recipe) -> FS layout.
+LAYOUTS: dict[str, FsLayout] = {
+    "XE5": _XE5,
+}
+
+
+def layout_for(model: str | None) -> FsLayout | None:
+    """Return the FS dial layout for a body, or None if unmapped."""
+    if model is None:
+        return None
+    normalized = "".join(
+        ch for ch in model.upper().replace("FUJIFILM", "") if ch.isalnum()
+    )
+    return LAYOUTS.get(normalized)
+
+
+def _tone_code(value: float) -> int:
+    """Encode highlight/shadow: raw = (value + 2) * 2, half steps."""
+    return round((value + 2) * 2)
+
+
+def _encode(
+    layout: FsLayout, slot: int, recipe: Recipe
+) -> tuple[dict[int, tuple[int, int]], list[str]]:
+    """Map a recipe to {offset: (value, size)} plus dropped fields."""
+
+    def at(name: str) -> FsField:
+        return layout.fields[name]
+
+    def offset(name: str) -> int:
+        field = at(name)
+        return field.offset + slot * field.step
+
+    out: dict[int, tuple[int, int]] = {}
+    dropped: list[str] = []
+
+    if recipe.film_simulation in _FS_FILM_SIMS:
+        out[offset("film_sim")] = (_FS_FILM_SIMS[recipe.film_simulation], 1)
+    else:
+        dropped.append(
+            f"film simulation {recipe.film_simulation} "
+            "(not yet verified on this body's FS dial)"
+        )
+
+    if recipe.dynamic_range in _DR_CODES:
+        out[offset("dr")] = (_DR_CODES[recipe.dynamic_range], 1)
+    else:
+        dropped.append(f"dynamic range {recipe.dynamic_range}")
+
+    out[offset("nr")] = (recipe.noise_reduction + 4, 1)
+    out[offset("clarity")] = (recipe.clarity + 6, 1)
+    out[offset("color")] = (7 - recipe.color, 1)
+    out[offset("sharpness")] = (4 - recipe.sharpness, 1)
+    out[offset("highlight")] = (_tone_code(recipe.highlights), 1)
+    out[offset("shadow")] = (_tone_code(recipe.shadows), 1)
+    out[offset("color_chrome")] = (_CHROME_CODES[recipe.color_chrome], 1)
+    out[offset("color_chrome_blue")] = (
+        _CHROME_CODES[recipe.color_chrome_blue],
+        1,
+    )
+    out[offset("grain_rough")] = (_GRAIN_ROUGH_CODES[recipe.grain], 1)
+    if recipe.grain != "Off":
+        out[offset("grain_size")] = (
+            _GRAIN_SIZE_CODES[recipe.grain_size],
+            1,
+        )
+    out[offset("smooth_skin")] = (_CHROME_CODES[recipe.smooth_skin], 1)
+
+    # White balance: "AsShot" leaves the slot's stored WB untouched.
+    if recipe.white_balance != "AsShot":
+        if recipe.white_balance in _WB_CODES:
+            out[offset("wb_mode")] = (_WB_CODES[recipe.white_balance], 1)
+            out[offset("wb_shift_r")] = (9 - recipe.wb_shift_r, 1)
+            out[offset("wb_shift_b")] = (9 - recipe.wb_shift_b, 1)
+            if recipe.white_balance == "Temperature":
+                out[offset("wb_kelvin")] = (recipe.color_temp, 2)
+        else:
+            dropped.append(f"white balance {recipe.white_balance}")
+
+    is_mono = recipe.film_simulation.startswith(_MONO_TONING_PREFIXES)
+    if is_mono and "mono_wc" in layout.fields:
+        out[offset("mono_wc")] = (_mono_code(recipe.mono_warm_cool), 1)
+        out[offset("mono_mg")] = (_mono_code(recipe.mono_magenta_green), 1)
+    elif is_mono and (recipe.mono_warm_cool or recipe.mono_magenta_green):
+        dropped.append("monochromatic color toning")
+
+    if recipe.exposure:
+        dropped.append("exposure compensation")
+
+    return out, dropped
+
+
+def unsupported_fields(layout: FsLayout, recipe: Recipe) -> list[str]:
+    """Recipe features an FS dial position cannot store."""
+    return _encode(layout, 0, recipe)[1]
+
+
+def write_fs_recipe(
+    blob: bytes, layout: FsLayout, slot: int, recipe: Recipe
+) -> bytes:
+    """Return a copy of blob with recipe written into FS slot.
+
+    Args:
+        blob: A settings-backup blob read from the camera.
+        layout: The connected body's FS layout (from layout_for).
+        slot: Zero-based dial position, 0..num_slots-1 (FS1..FSn).
+        recipe: The recipe to store there.
+
+    Raises:
+        BackupWriteError: On a bad slot or a blob-size mismatch.
+    """
+    if not 0 <= slot < layout.num_slots:
+        raise BackupWriteError(
+            f"FS slot {slot} out of range 0..{layout.num_slots - 1}"
+        )
+    if len(blob) != layout.blob_size:
+        raise BackupWriteError(
+            f"blob is {len(blob)} bytes, expected {layout.blob_size} for "
+            "this body"
+        )
+    encoded, _dropped = _encode(layout, slot, recipe)
+    out = bytearray(blob)
+    delta = 0
+    for off, (value, size) in encoded.items():
+        if size == _U16_SIZE:
+            old = out[off] + out[off + 1]
+            struct.pack_into("<H", out, off, value)
+            delta += out[off] + out[off + 1] - old
+        else:
+            if not 0 <= value <= _BYTE_MAX:
+                raise BackupWriteError(
+                    f"value {value} out of byte range at offset {off}"
+                )
+            delta += value - out[off]
+            out[off] = value
+    stored = struct.unpack_from("<H", out, _CHECKSUM_OFFSET)[0]
+    struct.pack_into("<H", out, _CHECKSUM_OFFSET, (stored + delta) & 0xFFFF)
+    return bytes(out)
+
+
+def write_fs_recipes(
+    blob: bytes, layout: FsLayout, assignments: dict[int, Recipe]
+) -> bytes:
+    """Write several FS slots at once (slot index -> recipe)."""
+    for slot, recipe in assignments.items():
+        blob = write_fs_recipe(blob, layout, slot, recipe)
+    return blob

--- a/src/grawji/preset_recipe.py
+++ b/src/grawji/preset_recipe.py
@@ -1,0 +1,255 @@
+"""Encode a Recipe as gen5 custom-preset PTP property writes.
+
+XProcessor5 bodies expose the C1-C7 custom settings as plain PTP device
+properties in USB RAW CONV./BACKUP RESTORE mode: 0xD18C selects the active
+slot, 0xD18D is the slot name, and 0xD18E-0xD1A5 are the slot's recipe values.
+Saving a preset is a bare sequence of SetDevicePropValue writes with no commit
+opcode.
+"""
+
+from __future__ import annotations
+
+import rawji
+from rawji.fuji_enums import (
+    ChromeEffect,
+    GrainEffect,
+    GrainEffectSize,
+    grain_effect_code,
+)
+from rawji.fuji_profile import encode_noise_reduction
+
+from grawji.backup_recipe import BackupWriteError
+from grawji.recipe import Recipe
+
+# Slot selector and slot name (not part of the recipe write list).
+PROP_PRESET_SLOT = 0xD18C
+PROP_PRESET_NAME = 0xD18D
+
+PROP_IMAGE_SIZE = 0xD18E
+PROP_IMAGE_QUALITY = 0xD18F
+PROP_DYNAMIC_RANGE = 0xD190
+PROP_UNKNOWN_D191 = 0xD191
+PROP_FILM_SIMULATION = 0xD192
+PROP_MONO_WC = 0xD193
+PROP_MONO_MG = 0xD194
+PROP_GRAIN = 0xD195
+PROP_COLOR_CHROME = 0xD196
+PROP_COLOR_CHROME_BLUE = 0xD197
+PROP_SMOOTH_SKIN = 0xD198
+PROP_WHITE_BALANCE = 0xD199
+PROP_WB_SHIFT_R = 0xD19A
+PROP_WB_SHIFT_B = 0xD19B
+PROP_WB_COLOR_TEMP = 0xD19C
+PROP_HIGHLIGHT = 0xD19D
+PROP_SHADOW = 0xD19E
+PROP_COLOR = 0xD19F
+PROP_SHARPNESS = 0xD1A0
+PROP_NOISE_REDUCTION = 0xD1A1
+PROP_CLARITY = 0xD1A2
+PROP_LONG_EXPOSURE_NR = 0xD1A3
+PROP_COLOR_SPACE = 0xD1A4
+PROP_UNKNOWN_D1A5 = 0xD1A5
+
+# Number of C1..Cn banks a gen5 body exposes over these properties.
+NUM_SLOTS = 7
+
+# Properties whose meaning is unknown or not a recipe field (image size,
+# image quality, long-exposure NR, colour space, two unknowns).
+PASSTHROUGH_DEFAULTS: dict[int, int] = {
+    PROP_IMAGE_SIZE: 7,  # L 3:2
+    PROP_IMAGE_QUALITY: 4,
+    PROP_UNKNOWN_D191: 0,
+    PROP_LONG_EXPOSURE_NR: 1,  # on
+    PROP_COLOR_SPACE: 1,  # sRGB
+    PROP_UNKNOWN_D1A5: 7,
+}
+
+# The tone/NR reads on some bodies return 0x8000 for a value the slot
+# never stored
+UNSET_SENTINEL = 0x8000
+
+# Grain Off writes as code 1, but gen5 bodies store an Off code that
+# keeps the grain-size half: the X-E5's factory slots hold 6 (Off after
+# Small) and an Off written over a Large-grain preset reads back 7
+# All decode as Off.
+_GRAIN_OFF_WRITE = 1
+_GRAIN_OFF_STORED = frozenset({6, 7})
+
+_DR_PERCENT = {"DR100": 100, "DR200": 200, "DR400": 400}
+
+# Only the Acros/Monochrome families take the mono toning values. Those
+# plus Sepia lock the colour axis (the camera greys it out), so the
+# colour property is omitted for them, as X Raw Studio does.
+_MONO_TONING_PREFIXES = ("Acros", "Monochrome")
+
+
+def _u16(value: int) -> int:
+    """Two's-complement a small signed value into a u16 wire value."""
+    return value & 0xFFFF
+
+
+def _x10(value: float) -> int:
+    """Encode a tone-style value as the value*10 i16 wire value."""
+    return _u16(round(value * 10))
+
+
+def _film_sim_code(name: str) -> int:
+    """The preset film-sim code (identical to the d185/rawji enum)."""
+    try:
+        return int(rawji.FilmSimulation[name])
+    except KeyError:
+        raise BackupWriteError(f"unknown film simulation {name!r}") from None
+
+
+def _chrome_code(value: str, label: str) -> int:
+    """Encode an Off/Weak/Strong strength (1/2/3, the ChromeEffect enum)."""
+    try:
+        return int(ChromeEffect[value])
+    except KeyError:
+        raise BackupWriteError(f"unknown {label} {value!r}") from None
+
+
+def unsupported_fields(recipe: Recipe) -> list[str]:
+    """Recipe features a gen5 preset cannot store (dropped on write)."""
+    dropped = []
+    if recipe.exposure:
+        dropped.append("exposure compensation")
+    return dropped
+
+
+def encode_recipe(
+    recipe: Recipe, base: dict[int, int] | None = None
+) -> list[tuple[int, int]]:
+    """Return the ordered (property, u16 value) write list for a recipe.
+
+    Args:
+        recipe: The recipe to encode.
+        base: The slot's current property values, echoed back for the
+            passthrough properties and for an "AsShot" white balance
+            (which leaves the slot's stored WB untouched). Properties
+            missing from base fall back to PASSTHROUGH_DEFAULTS, or are
+            omitted for the WB cluster.
+
+    Raises:
+        BackupWriteError: If an enum-valued field has no known code.
+    """
+    base = base or {}
+    sim = recipe.film_simulation
+    is_mono_toning = sim.startswith(_MONO_TONING_PREFIXES)
+
+    def passthrough(prop: int) -> tuple[int, int]:
+        return prop, base.get(prop, PASSTHROUGH_DEFAULTS[prop])
+
+    try:
+        dr = _DR_PERCENT[recipe.dynamic_range]
+    except KeyError:
+        raise BackupWriteError(
+            f"unknown dynamic range {recipe.dynamic_range!r}"
+        ) from None
+
+    props = [
+        passthrough(PROP_IMAGE_SIZE),
+        passthrough(PROP_IMAGE_QUALITY),
+        (PROP_DYNAMIC_RANGE, dr),
+        passthrough(PROP_UNKNOWN_D191),
+        (PROP_FILM_SIMULATION, _film_sim_code(sim)),
+    ]
+
+    if is_mono_toning and recipe.mono_warm_cool:
+        props.append((PROP_MONO_WC, _x10(recipe.mono_warm_cool)))
+    if is_mono_toning and recipe.mono_magenta_green:
+        props.append((PROP_MONO_MG, _x10(recipe.mono_magenta_green)))
+
+    grain = grain_effect_code(
+        GrainEffect[recipe.grain], GrainEffectSize[recipe.grain_size]
+    )
+    props.append((PROP_GRAIN, grain))
+    props.append(
+        (PROP_COLOR_CHROME, _chrome_code(recipe.color_chrome, "color chrome"))
+    )
+    props.append(
+        (
+            PROP_COLOR_CHROME_BLUE,
+            _chrome_code(recipe.color_chrome_blue, "color chrome blue"),
+        )
+    )
+    props.append(
+        (PROP_SMOOTH_SKIN, _chrome_code(recipe.smooth_skin, "smooth skin"))
+    )
+
+    props.extend(_wb_props(recipe, base))
+
+    props.append((PROP_HIGHLIGHT, _x10(recipe.highlights)))
+    props.append((PROP_SHADOW, _x10(recipe.shadows)))
+    if not is_mono_toning and sim != "Sepia":
+        props.append((PROP_COLOR, _x10(recipe.color)))
+    props.append((PROP_SHARPNESS, _x10(recipe.sharpness)))
+    props.append(
+        (PROP_NOISE_REDUCTION, encode_noise_reduction(recipe.noise_reduction))
+    )
+    props.append((PROP_CLARITY, _x10(recipe.clarity)))
+
+    props.append(passthrough(PROP_LONG_EXPOSURE_NR))
+    props.append(passthrough(PROP_COLOR_SPACE))
+    props.append(passthrough(PROP_UNKNOWN_D1A5))
+    return props
+
+
+def _wb_props(recipe: Recipe, base: dict[int, int]) -> list[tuple[int, int]]:
+    """The WB cluster: mode, then temperature, then the two shifts.
+
+    "AsShot" echoes the slot's current values so the stored WB survives
+    the full-sequence write; if the slot was not readable the cluster is
+    omitted and the stored values stand.
+    """
+    if recipe.white_balance == "AsShot":
+        if PROP_WHITE_BALANCE not in base:
+            return []
+        mode = base[PROP_WHITE_BALANCE]
+        props = [(PROP_WHITE_BALANCE, mode)]
+        if mode == int(rawji.WhiteBalance.Temperature):
+            kelvin = base.get(PROP_WB_COLOR_TEMP)
+            if kelvin:
+                props.append((PROP_WB_COLOR_TEMP, kelvin))
+        props.extend(
+            (prop, base[prop])
+            for prop in (PROP_WB_SHIFT_R, PROP_WB_SHIFT_B)
+            if prop in base
+        )
+        return props
+
+    try:
+        mode = int(rawji.WhiteBalance[recipe.white_balance])
+    except KeyError:
+        raise BackupWriteError(
+            f"unknown white balance {recipe.white_balance!r}"
+        ) from None
+    props = [(PROP_WHITE_BALANCE, mode)]
+    if recipe.white_balance == "Temperature":
+        props.append((PROP_WB_COLOR_TEMP, recipe.color_temp))
+    props.append((PROP_WB_SHIFT_R, _u16(recipe.wb_shift_r)))
+    props.append((PROP_WB_SHIFT_B, _u16(recipe.wb_shift_b)))
+    return props
+
+
+def readback_matches(prop: int, wrote: int, read: int) -> bool:
+    """Whether a read-back value confirms a written one."""
+    if read == wrote:
+        return True
+    if (
+        prop == PROP_GRAIN
+        and wrote == _GRAIN_OFF_WRITE
+        and read in _GRAIN_OFF_STORED
+    ):
+        return True
+    sentinel_props = (
+        PROP_MONO_WC,
+        PROP_MONO_MG,
+        PROP_HIGHLIGHT,
+        PROP_SHADOW,
+        PROP_COLOR,
+        PROP_SHARPNESS,
+        PROP_NOISE_REDUCTION,
+        PROP_CLARITY,
+    )
+    return prop in sentinel_props and read == UNSET_SENTINEL

--- a/src/grawji/views/recipe_manager.py
+++ b/src/grawji/views/recipe_manager.py
@@ -16,6 +16,7 @@ gi.require_version("Adw", "1")
 from gi.repository import Adw, Gdk, GdkPixbuf, Gio, GLib, GObject, Gtk
 
 from grawji import compatibility as compat
+from grawji import fs_recipe
 from grawji.fp_xml import parse_fp, serialize_fp
 from grawji.recipe import Recipe
 from grawji.recipes import UNGROUPED, RecipeLibrary
@@ -118,7 +119,8 @@ class RecipeManagerDialog(Adw.Dialog):
             Callable[[Callable[[list[str]], None]], None] | None
         ) = None,
         on_transfer: (
-            Callable[[dict[int, str], dict[int, str]], None] | None
+            Callable[[dict[int, str], dict[int, str], dict[int, str]], None]
+            | None
         ) = None,
     ) -> None:
         """Wire the dialog to the library (read) and intent callbacks."""
@@ -144,6 +146,8 @@ class RecipeManagerDialog(Adw.Dialog):
         self._groups: list[Adw.PreferencesGroup] = []
         self._banks: list[dict[str, Any]] = []
         self._bank_recipe: dict[int, str] = {}
+        self._fs_cards: list[dict[str, Any]] = []
+        self._fs_recipe: dict[int, str] = {}
         self._toast: Adw.Toast | None = None
 
         self.import_button.connect("clicked", lambda *_a: self._on_import())
@@ -253,10 +257,31 @@ class RecipeManagerDialog(Adw.Dialog):
         texture = _family_paintable(model)
         if texture is not None:
             self.camera_image.set_from_paintable(texture)
+        self.camera_banks.append(self._section_heading("Custom banks"))
         for slot in range(_BANK_COUNT):
             self.camera_banks.append(self._build_bank_card(slot))
+        self._build_fs_section(model)
         if self._load_bank_names is not None:
             self._load_bank_names(self.set_bank_names)
+
+    def _build_fs_section(self, model: str | None) -> None:
+        """Add FS1-FSn dial-position cards if this body has an FS layout."""
+        layout = fs_recipe.layout_for(model)
+        if layout is None:
+            return
+        self.camera_banks.append(
+            self._section_heading("Film-simulation dial (FS)")
+        )
+        for slot in range(layout.num_slots):
+            self.camera_banks.append(self._build_fs_card(slot))
+
+    def _section_heading(self, text: str) -> Gtk.Widget:
+        """A small heading that separates the bank and FS card groups."""
+        label = Gtk.Label(label=text, xalign=0)
+        label.add_css_class("heading")
+        label.add_css_class("dim-label")
+        label.set_margin_top(6)
+        return label
 
     def _build_bank_card(self, slot: int) -> Gtk.Widget:
         """A drop-target card for bank C{slot+1} with a rename affordance."""
@@ -307,6 +332,52 @@ class RecipeManagerDialog(Adw.Dialog):
         )
         return card
 
+    def _build_fs_card(self, slot: int) -> Gtk.Widget:
+        """A drop-target card for an FS dial position (no rename).
+
+        FS positions are physical dial presets, not user-named banks, so
+        the card carries only its fixed FS label and a drop area.
+        """
+        card = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        card.add_css_class("card")
+        inner = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=6,
+            margin_top=12,
+            margin_bottom=12,
+            margin_start=12,
+            margin_end=12,
+        )
+        card.append(inner)
+
+        title = Gtk.Label(label=f"FS{slot + 1}", xalign=0)
+        title.add_css_class("heading")
+        inner.append(title)
+
+        assigned = Gtk.Label(label="Drop a recipe here", xalign=0)
+        assigned.add_css_class("dim-label")
+        assigned.set_wrap(True)
+        inner.append(assigned)
+
+        drop = Gtk.DropTarget.new(GObject.TYPE_STRING, Gdk.DragAction.MOVE)
+        drop.connect("drop", self._on_fs_drop, slot)
+        card.add_controller(drop)
+
+        self._fs_cards.append({"assigned": assigned})
+        return card
+
+    def _compat_note(self, name: str) -> str:
+        """A short compatibility suffix for a recipe on this body."""
+        recipe = self._library.get(name)
+        if recipe is None or self._caps is None:
+            return ""
+        verdict = compat.evaluate(recipe, self._caps)
+        if verdict.level == compat.UNAVAILABLE:
+            return "  (film sim N/A here)"
+        if verdict.level == compat.DEGRADED:
+            return f"  ({len(verdict.issues)} dropped)"
+        return ""
+
     def _on_bank_drop(
         self, _target: Any, value: Any, _x: float, _y: float, slot: int
     ) -> bool:
@@ -316,15 +387,21 @@ class RecipeManagerDialog(Adw.Dialog):
             return False
         self._bank_recipe[slot] = name
         label = self._banks[slot]["assigned"]
-        recipe = self._library.get(name)
-        note = ""
-        if recipe is not None and self._caps is not None:
-            verdict = compat.evaluate(recipe, self._caps)
-            if verdict.level == compat.UNAVAILABLE:
-                note = "  (film sim N/A here)"
-            elif verdict.level == compat.DEGRADED:
-                note = f"  ({len(verdict.issues)} dropped)"
-        label.set_label(f"→ {name}{note}")
+        label.set_label(f"→ {name}{self._compat_note(name)}")
+        label.remove_css_class("dim-label")
+        self._dragged = None
+        return True
+
+    def _on_fs_drop(
+        self, _target: Any, value: Any, _x: float, _y: float, slot: int
+    ) -> bool:
+        """Assign the dropped recipe to FS dial position slot."""
+        name = value if isinstance(value, str) else self._dragged
+        if not name or self._library.get(name) is None:
+            return False
+        self._fs_recipe[slot] = name
+        label = self._fs_cards[slot]["assigned"]
+        label.set_label(f"→ {name}{self._compat_note(name)}")
         label.remove_css_class("dim-label")
         self._dragged = None
         return True
@@ -373,18 +450,23 @@ class RecipeManagerDialog(Adw.Dialog):
     def on_transfer_finished(self) -> None:
         """Refresh the bank pane after a transfer (reload names, clear)."""
         self._bank_recipe.clear()
-        for bank in self._banks:
-            bank["assigned"].set_label("Drop a recipe here")
-            bank["assigned"].add_css_class("dim-label")
+        self._fs_recipe.clear()
+        for card in (*self._banks, *self._fs_cards):
+            card["assigned"].set_label("Drop a recipe here")
+            card["assigned"].add_css_class("dim-label")
         if self._load_bank_names is not None:
             self._load_bank_names(self.set_bank_names)
 
     def _on_transfer_clicked(self, _button: Any) -> None:
-        """Hand the bank assignments and renames to the controller."""
+        """Hand the bank/FS assignments and renames to the controller."""
         if self._on_transfer is None:
             return
-        if self._bank_recipe or self._names_by_slot():
-            self._on_transfer(dict(self._bank_recipe), self._names_by_slot())
+        if self._bank_recipe or self._fs_recipe or self._names_by_slot():
+            self._on_transfer(
+                dict(self._bank_recipe),
+                self._names_by_slot(),
+                dict(self._fs_recipe),
+            )
 
     def _row_popover(self, name: str) -> Gtk.Popover:
         """The overflow menu for a recipe: move, rename, export, delete."""
@@ -634,7 +716,8 @@ class RecipeLibraryController:
             load_bank_names: Reads current bank names off the main thread
                 (calls its callback with them), or None.
             run_transfer: Performs the USB bank transfer off the main
-                thread (recipes, names, on_done, on_error), or None.
+                thread (recipes, names, fs_recipes, on_done, on_error),
+                or None.
         """
         self._parent = parent
         self._library = library
@@ -674,25 +757,35 @@ class RecipeLibraryController:
         self._manager.present(self._parent)
 
     def _transfer_banks(
-        self, assignments: dict[int, str], names: dict[int, str]
+        self,
+        assignments: dict[int, str],
+        names: dict[int, str],
+        fs_assignments: dict[int, str],
     ) -> None:
         """Resolve dropped recipe names and run the USB bank transfer."""
         if self._run_transfer is None:
             return
-        recipes: dict[int, Recipe] = {}
-        for slot, name in assignments.items():
-            recipe = self._library.get(name)
-            if recipe is not None:
-                recipes[slot] = recipe
-        if not recipes and not names:
+
+        def resolve(named: dict[int, str]) -> dict[int, Recipe]:
+            out: dict[int, Recipe] = {}
+            for slot, name in named.items():
+                recipe = self._library.get(name)
+                if recipe is not None:
+                    out[slot] = recipe
+            return out
+
+        recipes = resolve(assignments)
+        fs_recipes = resolve(fs_assignments)
+        if not recipes and not names and not fs_recipes:
             return
-        msg = f"Transferring {len(recipes)} recipe(s) to the camera…"
+        count = len(recipes) + len(fs_recipes)
+        msg = f"Transferring {count} recipe(s) to the camera…"
         if self._manager is not None:
             self._manager.set_busy(True)
             self._manager.show_toast(msg)
         self._on_status(msg)
         self._run_transfer(
-            recipes, names, self._on_bank_done, self._on_bank_fail
+            recipes, names, fs_recipes, self._on_bank_done, self._on_bank_fail
         )
 
     def _on_bank_done(self, message: str) -> None:

--- a/src/grawji/views/window.py
+++ b/src/grawji/views/window.py
@@ -803,27 +803,45 @@ class MainWindow(Adw.ApplicationWindow):
         self,
         recipes: dict[Any, Any],
         names: dict[Any, Any],
+        fs_recipes: dict[Any, Any],
         on_done: Callable[[str], None],
         on_error: Callable[[str], None],
     ) -> None:
-        """Transfer recipes to the camera's banks on a worker thread."""
+        """Transfer recipes to the camera's banks and FS dial on a worker."""
 
         def work() -> None:
+            written: list[str] = []
+            dropped: set[str] = set()
+            model = ""
             try:
-                result = self._session.transfer_bank_recipes(recipes, names)
+                if recipes or names:
+                    result = self._session.transfer_bank_recipes(
+                        recipes, names
+                    )
+                    model = result.model or model
+                    written += [f"C{i + 1}" for i in result.slots]
+                    dropped |= {
+                        f for fs in result.dropped.values() for f in fs
+                    }
+                if fs_recipes:
+                    result = self._session.transfer_fs_recipes(fs_recipes)
+                    model = result.model or model
+                    written += [f"FS{i + 1}" for i in result.slots]
+                    dropped |= {
+                        f for fs in result.dropped.values() for f in fs
+                    }
             except Exception as exc:
                 GLib.idle_add(on_error, f"Bank transfer failed: {exc}")
                 return
-            banks = ", ".join(f"C{i + 1}" for i in result.slots)
+            slots = ", ".join(written)
             message = (
-                f"Wrote recipes to {banks} on the {result.model}. "
+                f"Wrote recipes to {slots} on the {model}. "
                 "The live preview session was closed."
             )
-            if result.dropped:
-                unusable = sorted(
-                    {f for fields in result.dropped.values() for f in fields}
+            if dropped:
+                message += (
+                    " Dropped unsupported: " + ", ".join(sorted(dropped)) + "."
                 )
-                message += " Dropped unsupported: " + ", ".join(unusable) + "."
             GLib.idle_add(on_done, message)
 
         threading.Thread(target=work, daemon=True).start()

--- a/tests/test_camera_backup.py
+++ b/tests/test_camera_backup.py
@@ -9,8 +9,10 @@ from grawji.camera_backup import (
     BackupTransferError,
     classify_readback,
     model_from_blob,
+    transfer_fs_recipes,
     transfer_recipes,
 )
+from grawji.fs_recipe import _XE5
 from grawji.recipe import Recipe
 
 _GET_OBJECT_INFO = 0x1008
@@ -133,7 +135,7 @@ def test_transfer_raises_on_silent_no_op():
 
 def test_transfer_rejects_unsupported_body():
     """A body without a verified layout is refused before writing."""
-    cam = FakeCamera(_make_blob("X-E5", 70524))
+    cam = FakeCamera(_make_blob("X100V", 40000))
     with pytest.raises(BackupTransferError, match="no verified bank layout"):
         _run(cam, {0: Recipe()})
 
@@ -155,6 +157,66 @@ def test_empty_assignments_raise():
     cam = FakeCamera(_make_blob("X100F", 5660))
     with pytest.raises(BackupTransferError, match="no bank"):
         _run(cam, {})
+
+
+def _run_fs(cam, assignments):
+    """Drive transfer_fs_recipes with a fake camera reused for every phase."""
+    return transfer_fs_recipes(
+        lambda: cam, lambda _c: None, assignments, run_setup=False
+    )
+
+
+def test_fs_transfer_writes_and_verifies():
+    """An FS transfer patches the dial arrays and verifies them back."""
+    cam = FakeCamera(_make_blob("X-E5", 70524))
+    result = _run_fs(
+        cam,
+        {
+            2: Recipe(
+                film_simulation="Acros",
+                mono_warm_cool=-4,
+                mono_magenta_green=8,
+            )
+        },
+    )
+    assert result.model == "X-E5"
+    assert result.slots == (2,)
+    assert result.applied > 0
+    # FS3 film sim (0x16) and the two mono toning bytes (18 - value).
+    assert cam.blob[1997] == 0x16
+    assert cam.blob[34733] == 22
+    assert cam.blob[34739] == 10
+
+
+def test_fs_transfer_tolerates_camera_maintained_checksum():
+    """The camera re-stamping its checksum does not fail an FS transfer."""
+    cam = FakeCamera(_make_blob("X-E5", 70524), volatile={0x120: 0x99})
+    result = _run_fs(cam, {0: Recipe(film_simulation="Provia")})
+    assert result.applied > 0
+    assert cam.blob[_XE5.fields["film_sim"].offset] == 0x01
+
+
+def test_fs_transfer_raises_on_silent_no_op():
+    """A dial byte the camera silently keeps unchanged fails the transfer."""
+    off = _XE5.fields["film_sim"].offset
+    cam = FakeCamera(_make_blob("X-E5", 70524), ignore={off})
+    with pytest.raises(BackupTransferError, match="silently ignored"):
+        _run_fs(cam, {0: Recipe(film_simulation="Provia")})
+
+
+def test_fs_transfer_rejects_body_without_fs_layout():
+    """A body with no mapped FS dial layout is refused before writing."""
+    cam = FakeCamera(_make_blob("X-T3", 33404))
+    with pytest.raises(BackupTransferError, match="no mapped FS dial layout"):
+        _run_fs(cam, {0: Recipe()})
+    assert cam.restores == 0
+
+
+def test_fs_transfer_rejects_empty_assignments():
+    """An FS transfer with nothing to write is refused."""
+    cam = FakeCamera(_make_blob("X-E5", 70524))
+    with pytest.raises(BackupTransferError, match="no FS assignments"):
+        _run_fs(cam, {})
 
 
 def test_classify_readback_separates_ignored_from_maintained():

--- a/tests/test_camera_presets.py
+++ b/tests/test_camera_presets.py
@@ -1,0 +1,236 @@
+"""Tests for the gen5 preset transfer layer."""
+
+import struct
+from dataclasses import dataclass, field
+
+import pytest
+
+from grawji.camera_backup import (
+    BackupTransferError,
+    parse_device_info,
+    transfer_recipes,
+)
+from grawji.camera_presets import (
+    read_preset_names,
+    supports_presets,
+    transfer_presets,
+)
+from grawji.preset_recipe import (
+    PROP_CLARITY,
+    PROP_COLOR,
+    PROP_FILM_SIMULATION,
+    PROP_GRAIN,
+    PROP_PRESET_NAME,
+    PROP_PRESET_SLOT,
+    PROP_WB_SHIFT_R,
+    PROP_WHITE_BALANCE,
+)
+from grawji.recipe import Recipe
+
+_GET_DEVICE_INFO = 0x1001
+_GET_PROP = 0x1015
+_SET_PROP = 0x1016
+_PTP_OK = 0x2001
+_PTP_INVALID_VALUE = 0x201C
+
+
+@pytest.fixture(autouse=True)
+def _no_slot_switch_delay(monkeypatch):
+    """Skip the real camera's slot-switch settling wait in tests."""
+    monkeypatch.setattr("grawji.camera_presets._SLOT_SWITCH_DELAY_S", 0)
+
+
+def _ptp_string(text: str) -> bytes:
+    if not text:
+        return b"\x00"
+    encoded = (text + "\x00").encode("utf-16-le")
+    return bytes([len(encoded) // 2]) + encoded
+
+
+def _device_info(model: str, props: list[int]) -> bytes:
+    """A minimal PTP DeviceInfo dataset advertising the given props."""
+    out = bytearray()
+    out += struct.pack("<HIH", 100, 0, 0)  # version, ext id, ext version
+    out += _ptp_string("")  # VendorExtensionDesc
+    out += struct.pack("<H", 0)  # FunctionalMode
+    for array in ([0x1001], [], props, [], []):
+        out += struct.pack("<I", len(array))
+        out += struct.pack(f"<{len(array)}H", *array)
+    out += _ptp_string("FUJIFILM")
+    out += _ptp_string(model)
+    return bytes(out)
+
+
+@dataclass
+class _Slot:
+    """One fake preset slot: a name plus stored property values."""
+
+    name: str
+    props: dict[int, int] = field(default_factory=dict)
+
+
+class FakePresetCamera:
+    """In-memory gen5 body: 7 preset slots of device properties."""
+
+    def __init__(self, *, reject=(), ignore=(), grain_quirk=False):
+        """Slots start empty-ish; reject/ignore steer write behaviour."""
+        self.slots = [_Slot(name=f"BANK{i + 1}") for i in range(7)]
+        self.active = 3  # 1-based, like the camera
+        self.reject = set(reject)
+        self.ignore = set(ignore)
+        self.grain_quirk = grain_quirk
+
+    def _slot(self):
+        return self.slots[self.active - 1]
+
+    def send_command(self, code, params=None):
+        """Serve DeviceInfo and property reads."""
+        if code == _GET_DEVICE_INFO:
+            props = [PROP_PRESET_SLOT, PROP_PRESET_NAME]
+            return _PTP_OK, [], _device_info("X-E5", props)
+        if code == _GET_PROP:
+            prop = params[0]
+            if prop == PROP_PRESET_SLOT:
+                return _PTP_OK, [], struct.pack("<I", self.active)
+            if prop == PROP_PRESET_NAME:
+                return _PTP_OK, [], _ptp_string(self._slot().name)
+            value = self._slot().props.get(prop)
+            if value is None:
+                return _PTP_OK, [], b""
+            return _PTP_OK, [], struct.pack("<I", value)
+        return _PTP_OK, [], b""
+
+    def send_data_command(self, code, params, data):
+        """Accept property writes, honouring reject/ignore/quirk."""
+        if code != _SET_PROP:
+            return _PTP_OK, []
+        prop = params[0]
+        if prop == PROP_PRESET_SLOT:
+            self.active = struct.unpack_from("<H", data)[0]
+            return _PTP_OK, []
+        if prop == PROP_PRESET_NAME:
+            count = data[0]
+            text = data[1 : 1 + count * 2].decode("utf-16-le")
+            self._slot().name = text.rstrip("\x00")
+            return _PTP_OK, []
+        if prop in self.reject:
+            return _PTP_INVALID_VALUE, []
+        if prop in self.ignore:
+            return _PTP_OK, []  # ACK without storing
+        value = struct.unpack_from("<H", data)[0]
+        if self.grain_quirk and prop == PROP_GRAIN and value == 1:
+            value = 6  # the X-T5 family stores 6 for grain Off
+        self._slot().props[prop] = value
+        return _PTP_OK, []
+
+
+def test_supports_presets_needs_the_slot_prop():
+    """Only bodies advertising 0xD18C take the preset path."""
+    assert supports_presets(frozenset({PROP_PRESET_SLOT, 0xD185}))
+    assert not supports_presets(frozenset({0xD185}))
+
+
+def test_parse_device_info_reads_model_and_props():
+    """The DeviceInfo parser finds the model and the property list."""
+    info = parse_device_info(_device_info("X-E5", [PROP_PRESET_SLOT]))
+    assert info.model == "X-E5"
+    assert PROP_PRESET_SLOT in info.props
+    assert parse_device_info(b"junk").props == frozenset()
+
+
+def test_transfer_writes_and_verifies_a_slot():
+    """A recipe lands in the selected slot's properties, verified."""
+    cam = FakePresetCamera()
+    result = transfer_presets(
+        cam,
+        {0: Recipe(film_simulation="Velvia", white_balance="Daylight")},
+        names={0: "KODAK"},
+        model="X-E5",
+    )
+    assert result.model == "X-E5"
+    assert result.slots == (0,)
+    assert result.applied > 0
+    assert not result.dropped
+    slot = cam.slots[0]
+    assert slot.name == "KODAK"
+    assert slot.props[PROP_FILM_SIMULATION] == 2
+    assert slot.props[PROP_WHITE_BALANCE] == 0x0004
+    # The user's active slot selection was restored.
+    assert cam.active == 3
+
+
+def test_as_shot_leaves_the_slot_wb_untouched():
+    """An AsShot WB round-trips whatever WB the slot already held."""
+    cam = FakePresetCamera()
+    cam.slots[1].props[PROP_WHITE_BALANCE] = 0x8006  # Shade
+    cam.slots[1].props[PROP_WB_SHIFT_R] = 5
+    transfer_presets(cam, {1: Recipe()})
+    assert cam.slots[1].props[PROP_WHITE_BALANCE] == 0x8006
+    assert cam.slots[1].props[PROP_WB_SHIFT_R] == 5
+
+
+def test_mono_recipe_omits_color():
+    """A B&W recipe never writes the dual-use colour property."""
+    cam = FakePresetCamera()
+    transfer_presets(cam, {2: Recipe(film_simulation="Acros")})
+    assert PROP_COLOR not in cam.slots[2].props
+
+
+def test_grain_off_storage_quirk_is_not_a_failure():
+    """A body storing grain Off as 6 still verifies."""
+    cam = FakePresetCamera(grain_quirk=True)
+    result = transfer_presets(cam, {0: Recipe(grain="Off")})
+    assert cam.slots[0].props[PROP_GRAIN] == 6
+    assert result.applied > 0
+
+
+def test_silently_ignored_property_raises():
+    """An ACKed write that keeps the old value fails the transfer."""
+    cam = FakePresetCamera(ignore={PROP_FILM_SIMULATION})
+    cam.slots[0].props[PROP_FILM_SIMULATION] = 12  # stored Acros
+    with pytest.raises(BackupTransferError, match="silently ignored"):
+        transfer_presets(cam, {0: Recipe(film_simulation="Velvia")})
+
+
+def test_rejected_clarity_is_dropped_not_fatal():
+    """The known X-T5 clarity rejection becomes a dropped note."""
+    cam = FakePresetCamera(reject={PROP_CLARITY})
+    result = transfer_presets(cam, {0: Recipe(clarity=3)})
+    assert "clarity" in " ".join(result.dropped[0])
+    assert cam.slots[0].props[PROP_FILM_SIMULATION] == 1
+
+
+def test_other_rejections_are_fatal():
+    """An unexpected property rejection stops the transfer."""
+    cam = FakePresetCamera(reject={PROP_FILM_SIMULATION})
+    with pytest.raises(BackupTransferError, match="rejected"):
+        transfer_presets(cam, {0: Recipe(film_simulation="Velvia")})
+
+
+def test_slot_range_is_validated():
+    """Out-of-range bank indices are refused before any write."""
+    cam = FakePresetCamera()
+    with pytest.raises(BackupTransferError, match="out of range"):
+        transfer_presets(cam, {7: Recipe()})
+
+
+def test_read_preset_names_restores_the_active_slot():
+    """Names read across all slots, then the selection goes back."""
+    cam = FakePresetCamera()
+    names = read_preset_names(cam)
+    assert names == [f"BANK{i + 1}" for i in range(7)]
+    assert cam.active == 3
+
+
+def test_transfer_recipes_dispatches_to_the_preset_path():
+    """A body advertising 0xD18C routes through the property writer."""
+    cam = FakePresetCamera()
+    result = transfer_recipes(
+        lambda: cam,
+        lambda _c: None,
+        {0: Recipe(film_simulation="ClassicNeg")},
+        names={0: "PACIFIC"},
+    )
+    assert result.model == "X-E5"
+    assert cam.slots[0].props[PROP_FILM_SIMULATION] == 17
+    assert cam.slots[0].name == "PACIFIC"

--- a/tests/test_fs_recipe.py
+++ b/tests/test_fs_recipe.py
@@ -1,0 +1,265 @@
+"""Tests for the FS dial-preset encoder."""
+
+import struct
+
+import pytest
+
+from grawji.backup_recipe import BackupWriteError
+from grawji.fs_recipe import (
+    _XE5,
+    layout_for,
+    unsupported_fields,
+    write_fs_recipe,
+    write_fs_recipes,
+)
+from grawji.recipe import Recipe
+
+_CHECKSUM = 0x120
+
+
+def _blank() -> bytearray:
+    """A zeroed blob of the X-E5 size with a plausible checksum seed."""
+    blob = bytearray(_XE5.blob_size)
+    struct.pack_into("<H", blob, _CHECKSUM, 0x1000)
+    return blob
+
+
+def _field(blob: bytes, name: str, slot: int) -> int:
+    field = _XE5.fields[name]
+    off = field.offset + slot * field.step
+    if field.step == 2 and name == "wb_kelvin":
+        return struct.unpack_from("<H", blob, off)[0]
+    return blob[off]
+
+
+def test_verified_fs_dial_film_sim_codes():
+    """All 20 X-E5 FS dial sim codes, hardware-verified by dial sweep."""
+    blob = _blank()
+    sim_off = _XE5.fields["film_sim"].offset + 2 * _XE5.fields["film_sim"].step
+    verified = {
+        "Provia": 0x01,
+        "Astia": 0x02,
+        "Velvia": 0x04,
+        "Sepia": 0x06,
+        "Monochrome": 0x09,
+        "MonochromeR": 0x0A,
+        "MonochromeYe": 0x0B,
+        "MonochromeG": 0x0C,
+        "ProNegStd": 0x0D,
+        "ProNegHi": 0x0E,
+        "ClassicChrome": 0x0F,
+        "ClassicNeg": 0x10,
+        "NostalgicNeg": 0x11,
+        "RealaAce": 0x12,
+        "Eterna": 0x13,
+        "EternaBleach": 0x14,
+        "Acros": 0x16,
+        "AcrosR": 0x17,
+        "AcrosYe": 0x18,
+        "AcrosG": 0x19,
+    }
+    for name, code in verified.items():
+        out = write_fs_recipe(blob, _XE5, 2, Recipe(film_simulation=name))
+        assert out[sim_off] == code, name
+
+
+def test_layout_for_known_and_unknown():
+    """Only the X-E5 is mapped; other bodies yield None."""
+    assert layout_for("X-E5") is _XE5
+    assert layout_for("FUJIFILM X-E5") is _XE5
+    assert layout_for("X-T3") is None
+    assert layout_for(None) is None
+
+
+def test_encodes_every_mapped_field_at_its_offset():
+    """A full recipe lands each parameter at its FS3 offset, encoded."""
+    recipe = Recipe(
+        film_simulation="ClassicNeg",
+        white_balance="Temperature",
+        color_temp=5000,
+        dynamic_range="DR200",
+        grain="Weak",
+        grain_size="Large",
+        color_chrome="Strong",
+        color_chrome_blue="Weak",
+        smooth_skin="Strong",
+        highlights=-1.5,
+        shadows=1,
+        color=3,
+        sharpness=-2,
+        noise_reduction=-3,
+        clarity=4,
+        wb_shift_r=2,
+        wb_shift_b=-1,
+    )
+    out = write_fs_recipe(_blank(), _XE5, 2, recipe)  # FS3
+    assert _field(out, "film_sim", 2) == 0x10  # Classic Neg
+    assert _field(out, "wb_mode", 2) == 0x0A  # Temperature
+    assert _field(out, "wb_kelvin", 2) == 5000
+    assert _field(out, "dr", 2) == 2
+    assert _field(out, "nr", 2) == 1  # -3 + 4
+    assert _field(out, "clarity", 2) == 10  # 4 + 6
+    assert _field(out, "color", 2) == 4  # 7 - 3
+    assert _field(out, "sharpness", 2) == 6  # 4 - -2
+    assert _field(out, "highlight", 2) == 1  # (-1.5 + 2) * 2
+    assert _field(out, "shadow", 2) == 6  # (1 + 2) * 2
+    assert _field(out, "color_chrome", 2) == 2
+    assert _field(out, "color_chrome_blue", 2) == 1
+    assert _field(out, "grain_rough", 2) == 1  # Weak
+    assert _field(out, "grain_size", 2) == 1  # Large
+    assert _field(out, "smooth_skin", 2) == 2
+    assert _field(out, "wb_shift_r", 2) == 7  # 9 - 2
+    assert _field(out, "wb_shift_b", 2) == 10  # 9 - -1
+
+
+def test_slots_are_addressed_by_stride():
+    """FS1/FS2/FS3 write to adjacent elements of each array."""
+    blob = _blank()
+    for slot in range(3):
+        blob = write_fs_recipe(
+            blob, _XE5, slot, Recipe(film_simulation="Provia", color=slot)
+        )
+    # The film-sim table has a 3-byte stride; the rest are adjacent.
+    assert _field(blob, "film_sim", 0) == 0x01
+    assert _field(blob, "film_sim", 1) == 0x01
+    assert _field(blob, "film_sim", 2) == 0x01
+    assert _XE5.fields["color"].offset == 34752
+    assert _field(blob, "color", 0) == 7  # color 0
+    assert _field(blob, "color", 1) == 6  # color +1
+    assert _field(blob, "color", 2) == 5  # color +2
+
+
+def test_checksum_delta_tracks_the_content_change():
+    """The stored u16 checksum moves by exactly the byte delta."""
+    blob = _blank()
+    seed = struct.unpack_from("<H", blob, _CHECKSUM)[0]
+    out = write_fs_recipe(blob, _XE5, 2, Recipe(film_simulation="Provia"))
+    # Sum the changed content bytes (everything but the checksum field).
+    delta = sum(
+        out[i] - blob[i]
+        for i in range(len(blob))
+        if not _CHECKSUM <= i < _CHECKSUM + 2
+    )
+    got = struct.unpack_from("<H", out, _CHECKSUM)[0]
+    assert got == (seed + delta) & 0xFFFF
+
+
+def test_as_shot_leaves_wb_bytes_untouched():
+    """An AsShot recipe never writes the WB mode/shift/kelvin arrays."""
+    blob = _blank()
+    off = _XE5.fields["wb_mode"].offset + 2
+    blob[off] = 0x03  # a stored Daylight the recipe must not clobber
+    out = write_fs_recipe(blob, _XE5, 2, Recipe())  # default AsShot
+    assert out[off] == 0x03
+
+
+def test_grain_off_skips_the_size_byte():
+    """Grain Off writes roughness 2 and leaves the size element alone."""
+    blob = _blank()
+    size_off = _XE5.fields["grain_size"].offset + 2
+    blob[size_off] = 1  # a stored Large the recipe must not touch
+    out = write_fs_recipe(blob, _XE5, 2, Recipe(grain="Off"))
+    assert _field(out, "grain_rough", 2) == 2
+    assert out[size_off] == 1
+
+
+def test_mono_toning_written_only_for_bw_sims():
+    """Acros stores WC/MG as 18 - value; a colour sim leaves them alone."""
+    blob = _blank()
+    wc_off = _XE5.fields["mono_wc"].offset + 2
+    mg_off = _XE5.fields["mono_mg"].offset + 2
+    blob[wc_off] = 0x12  # neutral 18
+    blob[mg_off] = 0x12
+    # Hardware-verified encoding: WC -4 -> 22, MG +8 -> 10.
+    out = write_fs_recipe(
+        blob,
+        _XE5,
+        2,
+        Recipe(
+            film_simulation="Acros", mono_warm_cool=-4, mono_magenta_green=8
+        ),
+    )
+    assert out[wc_off] == 22
+    assert out[mg_off] == 10
+    # A colour sim must not touch these dual-use bytes.
+    out = write_fs_recipe(
+        _blank(), _XE5, 2, Recipe(film_simulation="Provia", mono_warm_cool=5)
+    )
+    assert out[wc_off] == 0  # left at the blank blob's zero
+    assert out[mg_off] == 0
+
+
+def test_mono_toning_clamps_to_the_axis_limit():
+    """Values beyond +-18 clamp so the byte stays in range."""
+    blob = _blank()
+    wc_off = _XE5.fields["mono_wc"].offset + 2
+    out = write_fs_recipe(
+        blob, _XE5, 2, Recipe(film_simulation="Monochrome", mono_warm_cool=99)
+    )
+    assert out[wc_off] == 0  # 18 - 18
+    out = write_fs_recipe(
+        blob,
+        _XE5,
+        2,
+        Recipe(film_simulation="Monochrome", mono_warm_cool=-99),
+    )
+    assert out[wc_off] == 36  # 18 - (-18)
+
+
+def test_unsupported_fields_flags_exposure():
+    """Exposure compensation is reported as dropped; mono now writes."""
+    fields = unsupported_fields(
+        _XE5, Recipe(film_simulation="Acros", mono_warm_cool=3, exposure=1.0)
+    )
+    assert "monochromatic color toning" not in fields
+    assert "exposure compensation" in fields
+
+
+def test_unmapped_film_sim_is_dropped_not_written():
+    """A body-unknown sim is reported and its byte left unchanged."""
+    blob = _blank()
+    sim_off = _XE5.fields["film_sim"].offset + 2 * _XE5.fields["film_sim"].step
+    blob[sim_off] = 0x0F  # stored Classic Chrome
+    # A hypothetical sim missing from the blob enum: force it via a name.
+    recipe = Recipe(film_simulation="NotARealSim")
+    fields = unsupported_fields(_XE5, recipe)
+    assert any("film simulation" in f for f in fields)
+    out = write_fs_recipe(blob, _XE5, 2, recipe)
+    assert out[sim_off] == 0x0F
+
+
+def test_slot_and_size_guards():
+    """A bad slot or wrong blob size raises before any write."""
+    with pytest.raises(BackupWriteError, match="out of range"):
+        write_fs_recipe(_blank(), _XE5, 3, Recipe())
+    with pytest.raises(BackupWriteError, match="expected"):
+        write_fs_recipe(bytearray(100), _XE5, 0, Recipe())
+
+
+def test_write_fs_recipes_batches_slots():
+    """Batch writing several FS slots applies each one."""
+    out = write_fs_recipes(
+        _blank(),
+        _XE5,
+        {0: Recipe(film_simulation="Provia"), 2: Recipe(color=4)},
+    )
+    assert _field(out, "film_sim", 0) == 0x01
+    assert _field(out, "color", 2) == 3  # 7 - 4
+
+
+def test_unverified_film_sim_is_dropped_never_guessed():
+    """A sim outside the verified dial table is dropped, not guessed.
+
+    A wrong FS sim code is accepted silently and renders the wrong sim
+    on the dial (the read-back cannot catch it), so anything not in the
+    swept table must leave the sim byte alone and report the drop.
+    """
+    blob = _blank()
+    sim_off = _XE5.fields["film_sim"].offset + 2 * _XE5.fields["film_sim"].step
+    blob[sim_off] = 0x10  # a stored Classic Neg the write must not disturb
+    recipe = Recipe(film_simulation="SomeFutureSim")
+    assert any(
+        "not yet verified" in f for f in unsupported_fields(_XE5, recipe)
+    )
+    out = write_fs_recipe(blob, _XE5, 2, recipe)
+    assert out[sim_off] == 0x10  # unchanged

--- a/tests/test_preset_recipe.py
+++ b/tests/test_preset_recipe.py
@@ -1,0 +1,184 @@
+"""Tests for the gen5 preset-property recipe encoder."""
+
+import pytest
+
+from grawji.backup_recipe import BackupWriteError
+from grawji.preset_recipe import (
+    PASSTHROUGH_DEFAULTS,
+    PROP_CLARITY,
+    PROP_COLOR,
+    PROP_COLOR_CHROME,
+    PROP_COLOR_CHROME_BLUE,
+    PROP_DYNAMIC_RANGE,
+    PROP_FILM_SIMULATION,
+    PROP_GRAIN,
+    PROP_HIGHLIGHT,
+    PROP_IMAGE_SIZE,
+    PROP_MONO_MG,
+    PROP_MONO_WC,
+    PROP_NOISE_REDUCTION,
+    PROP_SHADOW,
+    PROP_SHARPNESS,
+    PROP_SMOOTH_SKIN,
+    PROP_WB_COLOR_TEMP,
+    PROP_WB_SHIFT_B,
+    PROP_WB_SHIFT_R,
+    PROP_WHITE_BALANCE,
+    UNSET_SENTINEL,
+    encode_recipe,
+    readback_matches,
+    unsupported_fields,
+)
+from grawji.recipe import Recipe
+
+
+def _as_dict(props: list[tuple[int, int]]) -> dict[int, int]:
+    return dict(props)
+
+
+def test_encodes_the_d185_compatible_codes():
+    """Film sim, chrome, grain, NR and tones use the verified codes."""
+    recipe = Recipe(
+        film_simulation="Velvia",
+        dynamic_range="DR400",
+        grain="Weak",
+        grain_size="Large",
+        color_chrome="Strong",
+        color_chrome_blue="Weak",
+        smooth_skin="Off",
+        highlights=1.5,
+        shadows=-2,
+        color=3,
+        sharpness=-1,
+        noise_reduction=-4,
+        clarity=5,
+    )
+    got = _as_dict(encode_recipe(recipe))
+    assert got[PROP_FILM_SIMULATION] == 2  # Velvia in the rawji enum
+    assert got[PROP_DYNAMIC_RANGE] == 400  # raw percentage, not an index
+    assert got[PROP_GRAIN] == 4  # Weak/Large in the flat enum
+    assert got[PROP_COLOR_CHROME] == 3
+    assert got[PROP_COLOR_CHROME_BLUE] == 2
+    assert got[PROP_SMOOTH_SKIN] == 1
+    assert got[PROP_HIGHLIGHT] == 15  # value*10, half steps supported
+    assert got[PROP_SHADOW] == (-20) & 0xFFFF
+    assert got[PROP_COLOR] == 30
+    assert got[PROP_SHARPNESS] == (-10) & 0xFFFF
+    assert got[PROP_NOISE_REDUCTION] == 0x8000  # the NR code table
+    assert got[PROP_CLARITY] == 50
+
+
+def test_wb_temperature_follows_the_wb_mode():
+    """The colour temperature comes immediately after the WB mode."""
+    recipe = Recipe(
+        white_balance="Temperature",
+        color_temp=5150,
+        wb_shift_r=3,
+        wb_shift_b=-6,
+    )
+    props = encode_recipe(recipe)
+    order = [prop for prop, _ in props]
+    at = order.index(PROP_WHITE_BALANCE)
+    assert order[at + 1] == PROP_WB_COLOR_TEMP
+    got = _as_dict(props)
+    assert got[PROP_WHITE_BALANCE] == 0x8007
+    assert got[PROP_WB_COLOR_TEMP] == 5150
+    assert got[PROP_WB_SHIFT_R] == 3
+    assert got[PROP_WB_SHIFT_B] == (-6) & 0xFFFF
+
+
+def test_wb_mode_without_temperature_omits_the_kelvin_prop():
+    """A non-Temperature WB never writes the colour temperature."""
+    got = _as_dict(encode_recipe(Recipe(white_balance="Daylight")))
+    assert got[PROP_WHITE_BALANCE] == 0x0004
+    assert PROP_WB_COLOR_TEMP not in got
+
+
+def test_as_shot_echoes_the_slot_wb_or_omits_the_cluster():
+    """An AsShot WB preserves the slot's stored values on a full write."""
+    base = {
+        PROP_WHITE_BALANCE: 0x8007,
+        PROP_WB_COLOR_TEMP: 6500,
+        PROP_WB_SHIFT_R: 2,
+        PROP_WB_SHIFT_B: 8,
+    }
+    got = _as_dict(encode_recipe(Recipe(), base))
+    assert got[PROP_WHITE_BALANCE] == 0x8007
+    assert got[PROP_WB_COLOR_TEMP] == 6500
+    assert got[PROP_WB_SHIFT_R] == 2
+    assert got[PROP_WB_SHIFT_B] == 8
+    # Unreadable slot: the WB cluster is omitted, the stored values stand.
+    got = _as_dict(encode_recipe(Recipe()))
+    assert PROP_WHITE_BALANCE not in got
+    assert PROP_WB_SHIFT_R not in got
+
+
+def test_mono_sims_swap_color_for_the_toning_axes():
+    """Acros/Monochrome write WC/MG (when set) and never colour."""
+    recipe = Recipe(
+        film_simulation="AcrosYe", mono_warm_cool=4, mono_magenta_green=-2
+    )
+    got = _as_dict(encode_recipe(recipe))
+    assert PROP_COLOR not in got
+    assert got[PROP_MONO_WC] == 40
+    assert got[PROP_MONO_MG] == (-20) & 0xFFFF
+    # A zero axis is omitted: the camera rejects a write of 0.
+    got = _as_dict(encode_recipe(Recipe(film_simulation="Monochrome")))
+    assert PROP_MONO_WC not in got
+    assert PROP_MONO_MG not in got
+
+
+def test_sepia_locks_color_but_takes_no_toning():
+    """Sepia omits colour and ignores stray mono toning values."""
+    recipe = Recipe(film_simulation="Sepia", mono_warm_cool=5, color=2)
+    got = _as_dict(encode_recipe(recipe))
+    assert PROP_COLOR not in got
+    assert PROP_MONO_WC not in got
+
+
+def test_color_sims_never_write_the_toning_axes():
+    """A colour sim's WC/MG slots hold WB data and must stay untouched."""
+    recipe = Recipe(film_simulation="Provia", mono_warm_cool=5)
+    got = _as_dict(encode_recipe(recipe))
+    assert PROP_MONO_WC not in got
+    assert got[PROP_COLOR] == 0
+
+
+def test_passthrough_props_echo_the_base_or_fall_back():
+    """Unknown/non-recipe properties echo the slot's current values."""
+    base = {PROP_IMAGE_SIZE: 2}
+    got = _as_dict(encode_recipe(Recipe(), base))
+    assert got[PROP_IMAGE_SIZE] == 2
+    got = _as_dict(encode_recipe(Recipe()))
+    for prop, default in PASSTHROUGH_DEFAULTS.items():
+        assert got[prop] == default
+
+
+def test_unknown_enum_values_raise():
+    """Values with no verified code refuse to encode."""
+    with pytest.raises(BackupWriteError, match="film simulation"):
+        encode_recipe(Recipe(film_simulation="Kodachrome"))
+    with pytest.raises(BackupWriteError, match="white balance"):
+        encode_recipe(Recipe(white_balance="Moonlight"))
+    with pytest.raises(BackupWriteError, match="dynamic range"):
+        encode_recipe(Recipe(dynamic_range="DR800"))
+
+
+def test_unsupported_fields_reports_exposure_only():
+    """Exposure compensation is the one recipe field presets lack."""
+    assert unsupported_fields(Recipe()) == []
+    assert unsupported_fields(Recipe(exposure=1.0)) == [
+        "exposure compensation"
+    ]
+
+
+def test_readback_matches_accepts_the_storage_quirks():
+    """Grain Off 1->6 and the 0x8000 unset sentinel count as applied."""
+    assert readback_matches(PROP_FILM_SIMULATION, 2, 2)
+    assert not readback_matches(PROP_FILM_SIMULATION, 2, 3)
+    assert readback_matches(PROP_GRAIN, 1, 6)
+    assert readback_matches(PROP_GRAIN, 1, 7)  # Off after Large (X-E5)
+    assert not readback_matches(PROP_GRAIN, 2, 6)
+    assert readback_matches(PROP_NOISE_REDUCTION, 0x1000, UNSET_SENTINEL)
+    assert readback_matches(PROP_HIGHLIGHT, 15, UNSET_SENTINEL)
+    assert not readback_matches(PROP_FILM_SIMULATION, 2, UNSET_SENTINEL)

--- a/tests/test_recipe_manager_camera.py
+++ b/tests/test_recipe_manager_camera.py
@@ -69,13 +69,16 @@ def test_drop_assigns_recipe_and_transfer_collects(tmp_path: Any) -> None:
     dialog = _dialog(
         tmp_path,
         model="X-T3",
-        on_transfer=lambda a, n: captured.update(recipes=a, names=n),
+        on_transfer=lambda a, n, fs: captured.update(
+            recipes=a, names=n, fs=fs
+        ),
     )
     assert dialog._on_bank_drop(None, "Velvia look", 0.0, 0.0, 0) is True
     assert dialog._on_bank_drop(None, "Acros look", 0.0, 0.0, 3) is True
     pump()
     dialog._on_transfer_clicked(None)
     assert captured["recipes"] == {0: "Velvia look", 3: "Acros look"}
+    assert captured["fs"] == {}
 
 
 def test_drop_rejects_unknown_recipe(tmp_path: Any) -> None:
@@ -99,7 +102,9 @@ def test_bank_rename_is_collected(tmp_path: Any) -> None:
     dialog = _dialog(
         tmp_path,
         model="X-T3",
-        on_transfer=lambda a, n: captured.update(recipes=a, names=n),
+        on_transfer=lambda a, n, fs: captured.update(
+            recipes=a, names=n, fs=fs
+        ),
     )
     dialog.set_bank_names(["STD", "PORTRA", "", "", "", "", ""])
     dialog._on_bank_drop(None, "Velvia look", 0.0, 0.0, 0)
@@ -115,3 +120,56 @@ def test_name_row_visible_on_every_body(tmp_path: Any) -> None:
     for model in ("X-T3", "X100F"):
         dialog = _dialog(tmp_path, model=model)
         assert all(b["name_row"].get_visible() for b in dialog._banks)
+
+
+def test_fs_cards_only_on_bodies_with_an_fs_layout(tmp_path: Any) -> None:
+    """FS dial cards appear on the X-E5 but not on the X-T3."""
+    xe5 = _dialog(tmp_path, model="X-E5")
+    assert len(xe5._banks) == 7
+    assert len(xe5._fs_cards) == 3  # FS1-FS3
+    xt3 = _dialog(tmp_path, model="X-T3")
+    assert xt3._fs_cards == []
+
+
+def test_fs_drop_and_transfer_collects_separately(tmp_path: Any) -> None:
+    """FS drops land in their own channel, apart from the C banks."""
+    captured: dict[str, Any] = {}
+    dialog = _dialog(
+        tmp_path,
+        model="X-E5",
+        on_transfer=lambda a, n, fs: captured.update(
+            recipes=a, names=n, fs=fs
+        ),
+    )
+    assert dialog._on_bank_drop(None, "Velvia look", 0.0, 0.0, 0) is True
+    assert dialog._on_fs_drop(None, "Acros look", 0.0, 0.0, 2) is True
+    pump()
+    dialog._on_transfer_clicked(None)
+    assert captured["recipes"] == {0: "Velvia look"}
+    assert captured["fs"] == {2: "Acros look"}
+
+
+def test_fs_only_transfer_is_collected(tmp_path: Any) -> None:
+    """A transfer with only FS assignments still fires."""
+    captured: dict[str, Any] = {}
+    dialog = _dialog(
+        tmp_path,
+        model="X-E5",
+        on_transfer=lambda a, n, fs: captured.update(
+            recipes=a, names=n, fs=fs
+        ),
+    )
+    dialog._on_fs_drop(None, "Velvia look", 0.0, 0.0, 0)
+    pump()
+    dialog._on_transfer_clicked(None)
+    assert captured["fs"] == {0: "Velvia look"}
+    assert captured["recipes"] == {}
+
+
+def test_transfer_finished_clears_fs_assignments(tmp_path: Any) -> None:
+    """A finished transfer resets FS assignments too."""
+    dialog = _dialog(tmp_path, model="X-E5")
+    dialog._on_fs_drop(None, "Velvia look", 0.0, 0.0, 1)
+    assert dialog._fs_recipe == {1: "Velvia look"}
+    dialog.on_transfer_finished()
+    assert dialog._fs_recipe == {}


### PR DESCRIPTION
- Introduced back-end support for FS dial positions (FS1-FSn) on compatible bodies, including blob writing, read-back verification, and compatibility checks.
- Updated UI to include FS card slots with drag-and-drop functionality for recipe assignments.
- Enhanced transfer logic to handle both custom banks (C1-C7) and FS dials in a unified workflow.

- Should address #34 for most of the cameras