### PR TITLE
feat(core, ui): enhance recipe handling and simplify preferences

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: cmb-hashes
+        name: cmb-hashes
+        entry: python scripts/check_cmb_hashes.py
+        language: system
+        pass_filenames: false
+        always_run: true
+
       - id: version-consistency
         name: version-consistency
         entry: python scripts/check_version.py

--- a/scripts/check_cmb_hashes.py
+++ b/scripts/check_cmb_hashes.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Keep the Cambalache project's .ui hashes in sync with the .ui files."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+UI_DIR = Path("src/grawji/ui")
+CMB = UI_DIR / "grawji.cmb"
+_ENTRY = re.compile(r'<ui filename="([^"]+)" sha256="([0-9a-f]{64})"/>')
+
+
+def main() -> int:
+    """Rewrite stale hashes in grawji.cmb."""
+    text = CMB.read_text(encoding="utf-8")
+    changed: list[str] = []
+    missing: list[str] = []
+
+    def replace(match: re.Match[str]) -> str:
+        filename, stored = match.group(1), match.group(2)
+        path = UI_DIR / filename
+        if not path.exists():
+            missing.append(filename)
+            return match.group(0)
+        actual = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual != stored:
+            changed.append(filename)
+            return f'<ui filename="{filename}" sha256="{actual}"/>'
+        return match.group(0)
+
+    new_text = _ENTRY.sub(replace, text)
+
+    for filename in missing:
+        print(f"grawji.cmb references missing UI file: {filename}")
+    if changed:
+        CMB.write_text(new_text, encoding="utf-8")
+        for filename in changed:
+            print(f"updated grawji.cmb hash for {filename}")
+        print("grawji.cmb was out of date. re-stage it and commit again.")
+    if changed or missing:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/grawji/settings.py
+++ b/src/grawji/settings.py
@@ -7,6 +7,9 @@ import os
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+FROM_IMAGE = "__from_image__"
+FROM_IMAGE_LABEL = "From image"
+
 
 def config_dir() -> Path:
     """Return grawji's config directory (honours XDG_CONFIG_HOME)."""
@@ -30,9 +33,9 @@ class Settings:
     """User-configurable application settings.
 
     Attributes:
-        load_recipe_from_image: When True, selecting an image loads
-            its own in-camera recipe into the controls. When False,
-            the current recipe is kept and applied to the new image.
+        open_recipe: The sticky recipe selection applied to each opened
+            image. FROM_IMAGE loads each image's own in-camera recipe.
+            Any other value is a saved recipe name applied to every image.
         sidebar_width: Width of the left side panel in pixels; drag the
             pane handle to 0 to collapse it (remembered across runs).
         canvas_background: Preview background CSS class ("" = themed).
@@ -62,7 +65,7 @@ class Settings:
             on startup when it is still present. Empty means none.
     """
 
-    load_recipe_from_image: bool = True
+    open_recipe: str = FROM_IMAGE
     sidebar_width: int = 240
     canvas_background: str = ""
     last_folder: str = ""

--- a/src/grawji/ui/grawji.cmb
+++ b/src/grawji/ui/grawji.cmb
@@ -2,10 +2,10 @@
 <!DOCTYPE cambalache-project SYSTEM "cambalache-project.dtd">
 <!-- Created with Cambalache 1.0.3 -->
 <cambalache-project version="1.0.0" target_tk="gtk-4.0" depends="libadwaita-1">
-  <ui filename="preview_view.ui" sha256="4c77d3a98a26d6570c9e410add54cbb5ae1352d88c7a65419d0ed9804c912449"/>
+  <ui filename="preview_view.ui" sha256="7bc30eac8d07acbf92f7ff430280d28bc31f495235c2290d680527968432e996"/>
   <ui filename="recipe_panel.ui" sha256="30e5e8c4659cf6b54c0dbce9c2d2eecc69150d6777b3cb03325b5363bc8c2337"/>
   <ui filename="grawji.ui" sha256="5d52074208035ed9d05077a775f46379879b5d8b319524af89b243b709b73a0e"/>
   <ui filename="batch_export.ui" sha256="684f45e4fd429b17511ec6c3dad138195d605a5f3bf6e70491bceec54337273a"/>
-  <ui filename="preferences.ui" sha256="966f2d13871db7cf94261d3355d2fafab6a90fb7df4cd66cf8dc41509398ddd7"/>
-  <ui filename="recipe_manager.ui" sha256="c953c28b07cf239cb2a6b92bf07aec0cad8a7b002a3face2320f44b056afda31"/>
+  <ui filename="preferences.ui" sha256="c270830fb31238e7434b63296d7c5045d084cfa0f138ca9e83685c7a5d33b6ea"/>
+  <ui filename="recipe_manager.ui" sha256="573687eedca7a120f464fbd5ef4f1fa1d590c0784385534f84a7b4f25256a93b"/>
 </cambalache-project>

--- a/src/grawji/ui/preferences.ui
+++ b/src/grawji/ui/preferences.ui
@@ -47,12 +47,6 @@
           <object class="AdwPreferencesGroup">
             <property name="title">Behaviour</property>
             <child>
-              <object class="AdwSwitchRow" id="load_recipe_row">
-                <property name="title">Load recipe from selected image</property>
-                <property name="subtitle">Off: keep the current recipe and apply it to each image</property>
-              </object>
-            </child>
-            <child>
               <object class="AdwActionRow">
                 <property name="title">Filmstrip scroll speed</property>
                 <property name="subtitle">Pixels per second while holding an arrow</property>

--- a/src/grawji/views/preferences.py
+++ b/src/grawji/views/preferences.py
@@ -29,7 +29,6 @@ class PreferencesDialog(Adw.PreferencesDialog):
     __gtype_name__ = "GrawjiPreferencesDialog"
 
     color_scheme_row = Gtk.Template.Child()
-    load_recipe_row = Gtk.Template.Child()
     wb_grid_row = Gtk.Template.Child()
     jpeg_quality_scale = Gtk.Template.Child()
     glide_speed_scale = Gtk.Template.Child()
@@ -50,12 +49,10 @@ class PreferencesDialog(Adw.PreferencesDialog):
         scheme = settings.color_scheme
         index = _COLOR_SCHEMES.index(scheme) if scheme in _COLOR_SCHEMES else 0
         self.color_scheme_row.set_selected(index)
-        self.load_recipe_row.set_active(settings.load_recipe_from_image)
         self.wb_grid_row.set_active(settings.wb_grid_tint)
         self.jpeg_quality_scale.set_value(settings.jpeg_quality)
         self.glide_speed_scale.set_value(settings.nav_glide_speed)
         self.color_scheme_row.connect("notify::selected", self._on_edited)
-        self.load_recipe_row.connect("notify::active", self._on_edited)
         self.wb_grid_row.connect("notify::active", self._on_edited)
         self.jpeg_quality_scale.connect("value-changed", self._on_edited)
         self.glide_speed_scale.connect("value-changed", self._on_edited)
@@ -65,9 +62,6 @@ class PreferencesDialog(Adw.PreferencesDialog):
         self._settings.color_scheme = _COLOR_SCHEMES[
             self.color_scheme_row.get_selected()
         ]
-        self._settings.load_recipe_from_image = (
-            self.load_recipe_row.get_active()
-        )
         self._settings.wb_grid_tint = self.wb_grid_row.get_active()
         self._settings.jpeg_quality = int(self.jpeg_quality_scale.get_value())
         self._settings.nav_glide_speed = int(

--- a/src/grawji/views/recipe_panel.py
+++ b/src/grawji/views/recipe_panel.py
@@ -25,6 +25,7 @@ from rawji.fuji_enums import (
 
 from grawji.capabilities import FILM_SIMULATIONS, Capabilities
 from grawji.recipe import Recipe
+from grawji.settings import FROM_IMAGE, FROM_IMAGE_LABEL
 from grawji.views.widgets import MonoColorGrid, SliderRow, WBShiftGrid
 
 _FILM_SIMULATIONS = list(FILM_SIMULATIONS)
@@ -96,7 +97,8 @@ class RecipePanel(Adw.PreferencesPage):
         self._suppress_signals = False
         self._recipe_names: list[str] = []
         self._applied_recipe = Recipe()
-        self._active_label = "Default"
+        self._active_label = FROM_IMAGE_LABEL
+        self.recipe_button.set_label(FROM_IMAGE_LABEL)
 
         self._apply_actions = Gio.SimpleActionGroup()
         apply_action = Gio.SimpleAction.new("apply", GLib.VariantType.new("s"))
@@ -394,8 +396,11 @@ class RecipePanel(Adw.PreferencesPage):
             *(name for _folder, names in folders for name in names),
         ]
         menu = Gio.Menu()
+        # The dynamic "From image" selection is the default.
+        special = Gio.Menu()
+        special.append_item(self._apply_item(FROM_IMAGE_LABEL, FROM_IMAGE))
+        menu.append_section(None, special)
         top = Gio.Menu()
-        top.append_item(self._apply_item("—", ""))
         for name in ungrouped:
             top.append_item(self._apply_item(name, name))
         menu.append_section(None, top)
@@ -417,8 +422,8 @@ class RecipePanel(Adw.PreferencesPage):
 
     def sync_combo(self, label: str) -> None:
         """Show label on the picker button (or "—" if not a recipe)."""
-        shown = label if label in self._recipe_names else "—"
-        self.recipe_button.set_label(shown)
+        known = label == FROM_IMAGE_LABEL or label in self._recipe_names
+        self.recipe_button.set_label(label if known else "—")
 
     def set_controls_sensitive(self, enabled: bool) -> None:
         """Enable or disable every edit control (not the apply-combo)."""

--- a/src/grawji/views/window.py
+++ b/src/grawji/views/window.py
@@ -35,6 +35,8 @@ from grawji.preview import CameraWorker
 from grawji.recipe import Recipe
 from grawji.recipes import RecipeLibrary, recipes_path
 from grawji.settings import (
+    FROM_IMAGE,
+    FROM_IMAGE_LABEL,
     load_settings,
     save_settings,
     settings_path,
@@ -422,12 +424,7 @@ class MainWindow(Adw.ApplicationWindow):
         return GLib.SOURCE_REMOVE
 
     def _on_opened(self, generation: int, _result: object) -> None:
-        """Show the first preview, optionally from the image's recipe.
-
-        If the "load recipe from image" setting is on, the controls are
-        set to the image's own in-camera recipe first; otherwise the
-        current (sticky) recipe is kept and applied to the new image.
-        """
+        """Show the first preview, applying the sticky recipe selection."""
         if generation != self._generation:
             return  # a newer selection has superseded this open
         profile = self._session.profile
@@ -444,9 +441,16 @@ class MainWindow(Adw.ApplicationWindow):
             )
             self._notify_unverified(model)
         render_working = True
-        if profile is not None and self._settings.load_recipe_from_image:
+        selection = self._settings.open_recipe
+        saved = (
+            None
+            if selection == FROM_IMAGE
+            else self._recipe_library.get(selection)
+        )
+        from_image = selection == FROM_IMAGE or saved is None
+        if profile is not None and from_image:
             self.recipe_panel.set_active(
-                recipe_from_profile(profile), "From image"
+                recipe_from_profile(profile), FROM_IMAGE_LABEL
             )
             # The loaded recipe is the image's own, so the embedded JPEG
             # already shown is exactly what a render would produce - skip the
@@ -454,6 +458,8 @@ class MainWindow(Adw.ApplicationWindow):
             if self.preview_view.has_embedded_jpeg:
                 self._set_busy(busy=False, status="Ready.")
                 render_working = False
+        elif saved is not None:
+            self.recipe_panel.set_active(saved, selection)
         if render_working:
             self._render_preview()
         # Comparing carries across images: refresh the baseline for this one.
@@ -564,8 +570,23 @@ class MainWindow(Adw.ApplicationWindow):
             self._schedule_render()
 
     def _on_apply_recipe(self, _panel: Any, name: str) -> None:
-        """Apply the recipe chosen in the panel's apply-combo."""
-        self._library.apply(name)
+        """Apply and remember the recipe chosen in the panel's picker."""
+        self._settings.open_recipe = name
+        self._save_settings()
+        if name == FROM_IMAGE:
+            self._apply_from_image()
+        else:
+            self._library.apply(name)
+
+    def _apply_from_image(self) -> None:
+        """Load the open image's own in-camera recipe into the controls."""
+        profile = self._session.profile
+        if profile is None:
+            return
+        self.recipe_panel.set_active(
+            recipe_from_profile(profile), FROM_IMAGE_LABEL
+        )
+        self._render_if_open()
 
     def _reset_recipe(self) -> None:
         """Reset all controls to the default recipe."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,12 +1,17 @@
 """Tests for persistent application settings."""
 
-from grawji.settings import Settings, load_settings, save_settings
+from grawji.settings import (
+    FROM_IMAGE,
+    Settings,
+    load_settings,
+    save_settings,
+)
 
 
 def test_defaults():
     """Loading from a non-existent path returns defaults."""
     settings = load_settings_from_missing()
-    assert settings.load_recipe_from_image is True
+    assert settings.open_recipe == FROM_IMAGE
 
 
 def load_settings_from_missing():
@@ -21,7 +26,7 @@ def test_round_trip(tmp_path):
     path = tmp_path / "settings.json"
     save_settings(
         Settings(
-            load_recipe_from_image=False,
+            open_recipe="Portra",
             sidebar_width=200,
             canvas_background="canvas-white",
             last_folder="/photos/raf",
@@ -32,7 +37,7 @@ def test_round_trip(tmp_path):
         path,
     )
     loaded = load_settings(path)
-    assert loaded.load_recipe_from_image is False
+    assert loaded.open_recipe == "Portra"
     assert loaded.sidebar_width == 200
     assert loaded.canvas_background == "canvas-white"
     assert loaded.last_folder == "/photos/raf"
@@ -70,12 +75,12 @@ def test_view_state_defaults_empty():
 def test_unknown_keys_ignored(tmp_path):
     """Unknown keys in the file are ignored."""
     path = tmp_path / "settings.json"
-    path.write_text('{"load_recipe_from_image": false, "bogus": 1}')
-    assert load_settings(path).load_recipe_from_image is False
+    path.write_text('{"open_recipe": "Velvia", "bogus": 1}')
+    assert load_settings(path).open_recipe == "Velvia"
 
 
 def test_corrupt_file_returns_defaults(tmp_path):
     """A corrupt settings file falls back to defaults."""
     path = tmp_path / "settings.json"
     path.write_text("not json{")
-    assert load_settings(path).load_recipe_from_image is True
+    assert load_settings(path).open_recipe == FROM_IMAGE


### PR DESCRIPTION
- Replace "load_recipe_from_image" with flexible "open_recipe" setting, enabling sticky recipe selection or dynamic in-camera recipe loading.
- Update recipe picker to dynamically default to "From image" while supporting saved recipes.
- Remove "Load recipe from selected image" setting from preferences for a streamlined UI.
- Addresses #58 