### PR TITLE
feat(crop, ui): add crop/straighten editor with per-image sidecars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,10 @@ export.
   is what the camera would write.
 - **Full recipe control**: film simulation, white balance, dynamic range,
   highlights, shadows, color and sharpness.
-- **Start from the image's own settings** (toggleable) or keep a sticky recipe
-  and apply it across shots.
 - **Recipes**: save, apply and delete named recipes. Import and export them
   in X RAW Studio's FP format (FP1/FP2/FP3), so a recipe from Fujifilm X RAW
   Studio drops straight in (and back out). grawji maps the
   parameters it supports. Effects it does not model are left neutral.
-- **Filmstrip** browser with EXIF info for the selected RAF.
 - **Export** single images or batch-export a whole folder at full resolution.
 - **Experimental**: write recipes into the camera's C1-C7 custom banks
   over USB, on X-Processor 5 bodies and on the X100F/X-T3 generation, and
@@ -41,20 +38,23 @@ export.
   X-Processor 5 and X100F/X-T3 hardware. Every write is read back and
   checked. Values a body cannot store are reported as dropped instead of
   written wrong.
-- Keyboard shortcuts, pan/zoom with a darktable-style background, and a
-  remembered window size and last folder.
 
-## Architecture
+## Warranty disclaimer
 
-rawji is imported as a library. grawji is a GTK4 UI plus a thin adapter
-(`grawji.core`) around rawji's public API, following a **load-once,
-render-many** workflow:
+Fujifilm's official
+[Camera Control SDK page](https://www.fujifilm-x.com/global/camera-control-sdk/)
+states, verbatim:
 
-- **Open RAF** (once, slow): `connect → send_raf → get_profile`
-- **Change recipe** (often, fast — session + RAF stay open):
-  `rmw_patch(base, recipe) → set_profile → trigger_conversion → wait_for_result`
-- **Quit**: `disconnect`
+> USING THIS SDK TO CONNECT TO OR CONTROL, ANY COMPATIBLE FUJIFILM CAMERA
+> WILL VOID THE CAMERA'S LIMITED PRODUCT WARRANTY.
 
+grawji and rawji do not use that SDK, but they talk to the camera over the
+same USB protocol and are not licensed by Fujifilm.
+[Reporting based on statements from Fujifilm](https://fujixweekly.com/2026/06/08/your-cameras-warranty-might-be-voided/)
+says the policy extends to any non-licensed program connecting to the
+camera, and that the camera records a marker each time one connects.
+Consumer-protection law in your country may limit or override such terms,
+but do not count on it: **use grawji at your own risk.**
 
 ## Install
 
@@ -139,7 +139,7 @@ make run        # or: .venv/bin/python -m grawji
 ```
 
 USB access: most distributions already grant non-root access via `uaccess` or
-`plugdev`; if yours does not, add a udev rule for the Fuji vendor id `0x04cb`
+`plugdev`. If yours does not, add a udev rule for the Fuji vendor id `0x04cb`
 (check first).
 
 </details>

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -46,7 +46,7 @@ and the live profile can only narrow a row, never widen it.
 | X-T30 III * | 2025 | X-Processor 5 | Y | Y | Y | Y | Y | Y | Y | Reala Ace |
 
 `*` X-M5 and X-T30 III pair the X-Processor 5 with the older X-Trans 4
-sensor; feature set follows the processor.
+sensor. Feature set follows the processor.
 
 ## GFX series
 

--- a/docs/usb-capture.md
+++ b/docs/usb-capture.md
@@ -39,13 +39,13 @@ Keeping the toggle to a single setting is what makes the diff readable.
 
 Open the pcap in Wireshark and look at the bulk OUT transfers to the
 camera's device address. X Raw Studio uploads the profile as PTP
-property 0xd185; the payload is easy to spot by its size (601, 605 or
+property 0xd185. The payload is easy to spot by its size (601, 605 or
 629 bytes depending on the body - it starts with a u16 parameter count
 followed by the length-prefixed wide-char IOPCode).
 
 Extract the profile payload sent before and after the toggle and diff
-them byte-wise. Exactly one 4-byte little-endian slot should differ;
-its offset is `513 + index * 4`. If more than one slot moved, the
+them byte-wise. Exactly one 4-byte little-endian slot should differ.
+Its offset is `513 + index * 4`. If more than one slot moved, the
 capture mixed edits - redo it. The value pair tells you the encoding
 (e.g. Clarity -5/+5 showed -50/+50, so the slot encodes value*10).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ check_untyped_defs = true
 disallow_untyped_calls = false
 
 [[tool.mypy.overrides]]
-module = ["rawji.*", "usb.*"]
+module = ["rawji.*", "usb.*", "cairo"]
 ignore_missing_imports = true
 
 # pygobject-stubs is installed for editor type hints, but grawji treats the

--- a/src/grawji/crop.py
+++ b/src/grawji/crop.py
@@ -1,0 +1,657 @@
+"""Crop and fine-rotate geometry.
+
+The camera engine has no crop or rotate, so grawji applies geometry to
+the jpeg the camera returns. A CropRotate describes that step in a
+resolution-independent way: the crop rect is normalized to the bounding
+box of the fine-rotated image, so the same value applies to the small
+preview render and the full-resolution export.
+
+The pipeline order is: exif orientation, then the coarse 90-degree
+orientation, then the fine angle, then the crop.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+Rect = tuple[float, float, float, float]
+
+FULL_RECT: Rect = (0.0, 0.0, 1.0, 1.0)
+MAX_ANGLE = 45.0
+MIN_SIZE = 0.05
+SIDECAR_SUFFIX = ".grawji.json"
+
+_log = logging.getLogger("grawji")
+
+
+@dataclass(frozen=True)
+class CropRotate:
+    """Geometry applied to a rendered jpeg, all resolution-independent."""
+
+    orientation: int = 0
+    angle: float = 0.0
+    rect: Rect = FULL_RECT
+    aspect: str = "Original"
+    aspect_swapped: bool = False
+
+    @property
+    def is_identity(self) -> bool:
+        """Whether this geometry changes nothing."""
+        return (
+            self.orientation == 0
+            and self.angle == 0.0
+            and self.rect == FULL_RECT
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a plain dict suitable for the sidecar storage."""
+        return {
+            "orientation": self.orientation,
+            "angle": self.angle,
+            "rect": list(self.rect),
+            "aspect": self.aspect,
+            "aspect_swapped": self.aspect_swapped,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> CropRotate:
+        """Build a CropRotate from a stored dict."""
+        orientation = data.get("orientation", 0)
+        if orientation not in (0, 90, 180, 270):
+            orientation = 0
+        angle = data.get("angle", 0.0)
+        if not isinstance(angle, (int, float)):
+            angle = 0.0
+        angle = max(-MAX_ANGLE, min(MAX_ANGLE, float(angle)))
+        rect = data.get("rect")
+        aspect = data.get("aspect", "Free")
+        if not isinstance(aspect, str):
+            aspect = "Free"
+        return cls(
+            orientation=int(orientation),
+            angle=angle,
+            rect=_sane_rect(rect),
+            aspect=aspect,
+            aspect_swapped=bool(data.get("aspect_swapped", False)),
+        )
+
+
+_RECT_LEN = 4
+_TINY = 1e-12
+
+
+def _sane_rect(value: object) -> Rect:
+    """Validate a stored rect, falling back to the full frame."""
+    if not isinstance(value, (list, tuple)) or len(value) != _RECT_LEN:
+        return FULL_RECT
+    if not all(isinstance(v, (int, float)) for v in value):
+        return FULL_RECT
+    x, y, w, h = (float(v) for v in value)
+    if w < MIN_SIZE or h < MIN_SIZE:
+        return FULL_RECT
+    x = max(0.0, min(x, 1.0 - MIN_SIZE))
+    y = max(0.0, min(y, 1.0 - MIN_SIZE))
+    w = max(MIN_SIZE, min(w, 1.0 - x))
+    h = max(MIN_SIZE, min(h, 1.0 - y))
+    return (x, y, w, h)
+
+
+def rotated_size(w: float, h: float, angle: float) -> tuple[float, float]:
+    """Bounding-box size of a image rotated by angle degrees."""
+    rad = math.radians(angle)
+    c, s = abs(math.cos(rad)), abs(math.sin(rad))
+    return w * c + h * s, w * s + h * c
+
+
+def fits(w: float, h: float, angle: float, rect: Rect) -> bool:
+    """Whether rect lies on pixels."""
+    bw, bh = rotated_size(w, h, angle)
+    rad = math.radians(angle)
+    c, s = math.cos(rad), math.sin(rad)
+    tol = 1e-6 * (w + h)
+    x, y, rw, rh = rect
+    for fx in (x, x + rw):
+        for fy in (y, y + rh):
+            px = fx * bw - bw / 2
+            py = fy * bh - bh / 2
+            ix = px * c + py * s
+            iy = -px * s + py * c
+            if abs(ix) > w / 2 + tol or abs(iy) > h / 2 + tol:
+                return False
+    return True
+
+
+def largest_fit(w: float, h: float, angle: float, ratio: float) -> Rect:
+    """Largest centered crop of the given pixel aspect that fits."""
+    rad = math.radians(angle)
+    c, s = math.cos(rad), math.sin(rad)
+    aw, ah = ratio, 1.0
+    scale = math.inf
+    for cy in (ah, -ah):
+        ix = abs(aw * c + cy * s)
+        iy = abs(-aw * s + cy * c)
+        if ix > _TINY:
+            scale = min(scale, (w / 2) / ix)
+        if iy > _TINY:
+            scale = min(scale, (h / 2) / iy)
+    bw, bh = rotated_size(w, h, angle)
+    cw = 2 * scale * aw / bw
+    ch = 2 * scale * ah / bh
+    cw, ch = min(cw, 1.0), min(ch, 1.0)
+    return ((1.0 - cw) / 2, (1.0 - ch) / 2, cw, ch)
+
+
+def shrink_to_fit(w: float, h: float, angle: float, rect: Rect) -> Rect:
+    """Scale rect about its own center until it fits on pixels."""
+    if fits(w, h, angle, rect):
+        return rect
+    x, y, rw, rh = rect
+    cx, cy = x + rw / 2, y + rh / 2
+
+    def scaled(t: float) -> Rect:
+        return (cx - rw * t / 2, cy - rh * t / 2, rw * t, rh * t)
+
+    if not fits(w, h, angle, scaled(0.0)):
+        bw, bh = rotated_size(w, h, angle)
+        return largest_fit(w, h, angle, (rw * bw) / (rh * bh))
+    lo, hi = 0.0, 1.0
+    for _ in range(40):
+        mid = (lo + hi) / 2
+        if fits(w, h, angle, scaled(mid)):
+            lo = mid
+        else:
+            hi = mid
+    return scaled(lo)
+
+
+def _origin_constraints(
+    w: float, h: float, angle: float, rw: float, rh: float
+) -> list[tuple[float, float, float]]:
+    """Half-planes for legal rect origins."""
+    bw, bh = rotated_size(w, h, angle)
+    rad = math.radians(angle)
+    c, s = math.cos(rad), math.sin(rad)
+    constraints: list[tuple[float, float, float]] = []
+    for gx, gy, half in ((bw * c, bh * s, w / 2), (-bw * s, bh * c, h / 2)):
+        biases = [
+            gx * (ax - 0.5) + gy * (ay - 0.5)
+            for ax in (0.0, rw)
+            for ay in (0.0, rh)
+        ]
+        constraints.append((gx, gy, half - max(biases)))
+        constraints.append((-gx, -gy, half + min(biases)))
+    return constraints
+
+
+def _project_origin(
+    constraints: list[tuple[float, float, float]],
+    tx: float,
+    ty: float,
+    fallback: tuple[float, float],
+    tol: float,
+) -> tuple[float, float]:
+    """The point of the constraint polygon closest to."""
+
+    def ok(px: float, py: float) -> bool:
+        return all(nx * px + ny * py <= d + tol for nx, ny, d in constraints)
+
+    if ok(tx, ty):
+        return tx, ty
+    best = fallback
+    best_d2 = math.inf
+    for nx, ny, d in constraints:
+        nn = nx * nx + ny * ny
+        if nn < _TINY:
+            continue
+        t = (nx * tx + ny * ty - d) / nn
+        px, py = tx - t * nx, ty - t * ny
+        d2 = (px - tx) ** 2 + (py - ty) ** 2
+        if d2 < best_d2 and ok(px, py):
+            best, best_d2 = (px, py), d2
+    for i, (n1x, n1y, d1) in enumerate(constraints):
+        for n2x, n2y, d2c in constraints[i + 1 :]:
+            det = n1x * n2y - n1y * n2x
+            if abs(det) < _TINY:
+                continue
+            px = (d1 * n2y - d2c * n1y) / det
+            py = (n1x * d2c - n2x * d1) / det
+            dd = (px - tx) ** 2 + (py - ty) ** 2
+            if dd < best_d2 and ok(px, py):
+                best, best_d2 = (px, py), dd
+    return best
+
+
+def clamp_move(
+    w: float, h: float, angle: float, rect: Rect, dx: float, dy: float
+) -> Rect:
+    """Move rect by, stopped exactly at the rotated image.
+
+    The target origin is projected onto the parallelogram of legal
+    origins, so the rect reaches every position the pixels allow and
+    glides along tilted edges instead of stopping early.
+    """
+    x, y, rw, rh = rect
+    constraints = _origin_constraints(w, h, angle, rw, rh)
+    tol = 1e-7 * (w + h)
+    ox, oy = _project_origin(constraints, x + dx, y + dy, (x, y), tol)
+    return (ox, oy, rw, rh)
+
+
+def constrain_drag(  # noqa: PLR0913
+    w: float,
+    h: float,
+    angle: float,
+    rect: Rect,
+    zone: str,
+    *,
+    dx: float,
+    dy: float,
+    ratio: float | None = None,
+) -> Rect:
+    """Apply a drag to rect, limited to stay on rotated image pixels."""
+    if not fits(w, h, angle, rect):
+        rect = shrink_to_fit(w, h, angle, rect)
+    candidate = apply_drag(rect, zone, dx, dy, ratio=ratio)
+    if fits(w, h, angle, candidate):
+        return candidate
+    if zone == "move":
+        return clamp_move(w, h, angle, rect, dx, dy)
+    if ratio is None and len(zone) == 2:  # noqa: PLR2004
+        part = _max_drag(w, h, angle, rect, zone, dx=dx, dy=0.0, ratio=None)
+        return _max_drag(w, h, angle, part, zone, dx=0.0, dy=dy, ratio=None)
+    return _max_drag(w, h, angle, rect, zone, dx=dx, dy=dy, ratio=ratio)
+
+
+def _max_drag(  # noqa: PLR0913
+    w: float,
+    h: float,
+    angle: float,
+    rect: Rect,
+    zone: str,
+    *,
+    dx: float,
+    dy: float,
+    ratio: float | None,
+) -> Rect:
+    """The largest achievable fraction of a drag applied to rect.
+
+    A candidate counts as achievable if it fits outright, or fits
+    after sliding the rect minimally along the tilted image edge.
+    Without the slide, a crop hugging the border at a near-zero angle
+    is blocked by fractions of a pixel. With it, growth continues
+    until the size genuinely no longer fits anywhere.
+    """
+    tol = 1e-7 * (w + h)
+
+    def fitted(t: float) -> Rect | None:
+        cand = apply_drag(rect, zone, dx * t, dy * t, ratio=ratio)
+        if fits(w, h, angle, cand):
+            return cand
+        x, y, rw, rh = cand
+        constraints = _origin_constraints(w, h, angle, rw, rh)
+        ox, oy = _project_origin(constraints, x, y, (x, y), tol)
+        moved = (ox, oy, rw, rh)
+        return moved if fits(w, h, angle, moved) else None
+
+    full = fitted(1.0)
+    if full is not None:
+        return full
+    best = rect
+    lo, hi = 0.0, 1.0
+    for _ in range(30):
+        mid = (lo + hi) / 2
+        cand = fitted(mid)
+        if cand is not None:
+            best, lo = cand, mid
+        else:
+            hi = mid
+    return best
+
+
+def swap_rect(w: float, h: float, angle: float, rect: Rect) -> Rect:
+    """The crop rect with its pixel width and height exchanged.
+
+    Turns a landscape selection into the portrait of the same pixel
+    size, kept at its center and shrunk to stay on pixels.
+    """
+    bw, bh = rotated_size(w, h, angle)
+    x, y, rw, rh = rect
+    nw, nh = (rh * bh) / bw, (rw * bw) / bh
+    scale = min(1.0, 1.0 / nw, 1.0 / nh)
+    nw, nh = nw * scale, nh * scale
+    nx = min(max(x + rw / 2 - nw / 2, 0.0), 1.0 - nw)
+    ny = min(max(y + rh / 2 - nh / 2, 0.0), 1.0 - nh)
+    return shrink_to_fit(w, h, angle, (nx, ny, nw, nh))
+
+
+def rotate_rect_90(rect: Rect, degrees: int) -> Rect:
+    """Carry a normalized crop rect through a 90-degree step rotation."""
+    x, y, w, h = rect
+    step = degrees % 360
+    if step == 90:  # noqa: PLR2004
+        return (1.0 - y - h, x, h, w)
+    if step == 180:  # noqa: PLR2004
+        return (1.0 - x - w, 1.0 - y - h, w, h)
+    if step == 270:  # noqa: PLR2004
+        return (y, 1.0 - x - w, h, w)
+    return rect
+
+
+def hit_zone(  # noqa: PLR0911
+    rect: Rect, x: float, y: float, mx: float, my: float
+) -> str | None:
+    """The drag zone under: a corner, an edge, move or None.
+
+    Args:
+        rect: The crop rect, normalized.
+        x: Pointer x, normalized.
+        y: Pointer y, normalized.
+        mx: Horizontal grab margin, normalized.
+        my: Vertical grab margin, normalized.
+    """
+    rx, ry, rw, rh = rect
+    left, right = rx, rx + rw
+    top, bottom = ry, ry + rh
+    near_l, near_r = abs(x - left) <= mx, abs(x - right) <= mx
+    near_t, near_b = abs(y - top) <= my, abs(y - bottom) <= my
+    in_x = left - mx <= x <= right + mx
+    in_y = top - my <= y <= bottom + my
+    if near_l and near_t:
+        return "nw"
+    if near_r and near_t:
+        return "ne"
+    if near_l and near_b:
+        return "sw"
+    if near_r and near_b:
+        return "se"
+    if near_t and in_x:
+        return "n"
+    if near_b and in_x:
+        return "s"
+    if near_l and in_y:
+        return "w"
+    if near_r and in_y:
+        return "e"
+    if left <= x <= right and top <= y <= bottom:
+        return "move"
+    return None
+
+
+def apply_drag(  # noqa: PLR0913
+    rect: Rect,
+    zone: str,
+    dx: float,
+    dy: float,
+    *,
+    ratio: float | None = None,
+    min_w: float = MIN_SIZE,
+    min_h: float = MIN_SIZE,
+    bounds: Rect = FULL_RECT,
+) -> Rect:
+    """The crop rect after dragging zone by, normalized."""
+    x, y, w, h = rect
+    bx, by, bw, bh = bounds
+    if zone == "move":
+        return (
+            max(bx, min(x + dx, bx + bw - w)),
+            max(by, min(y + dy, by + bh - h)),
+            w,
+            h,
+        )
+    left, right = x, x + w
+    top, bottom = y, y + h
+    if "w" in zone:
+        left = max(bx, min(left + dx, right - min_w))
+    if "e" in zone:
+        right = max(left + min_w, min(right + dx, bx + bw))
+    if "n" in zone:
+        top = max(by, min(top + dy, bottom - min_h))
+    if "s" in zone:
+        bottom = max(top + min_h, min(bottom + dy, by + bh))
+    if ratio is not None:
+        left, top, right, bottom = _apply_ratio(
+            zone,
+            ratio,
+            (left, top, right, bottom),
+            (w, h),
+            (min_w, min_h),
+            bounds,
+        )
+    return (left, top, right - left, bottom - top)
+
+
+def _apply_ratio(
+    zone: str,
+    ratio: float,
+    box: tuple[float, float, float, float],
+    ref: tuple[float, float],
+    mins: tuple[float, float],
+    bounds: Rect,
+) -> tuple[float, float, float, float]:
+    """Re-shape a dragged box to the given normalized aspect ratio."""
+    left, top, right, bottom = box
+    w, h = _ratio_size(
+        zone, ratio, (right - left, bottom - top), ref, mins, bounds
+    )
+    if zone in ("w", "e"):
+        cy = (top + bottom) / 2
+        top, bottom = cy - h / 2, cy + h / 2
+    elif zone in ("n", "s"):
+        cx = (left + right) / 2
+        left, right = cx - w / 2, cx + w / 2
+    if "n" in zone:
+        top = bottom - h
+    elif "s" in zone:
+        bottom = top + h
+    if "w" in zone:
+        left = right - w
+    elif "e" in zone:
+        right = left + w
+    return _slide_into((left, top, right, bottom), bounds)
+
+
+def _ratio_size(
+    zone: str,
+    ratio: float,
+    size: tuple[float, float],
+    ref: tuple[float, float],
+    mins: tuple[float, float],
+    bounds: Rect,
+) -> tuple[float, float]:
+    """The re-shaped of a ratio-bound drag."""
+    w, h = size
+    ref_w, ref_h = ref
+    min_w, min_h = mins
+    width_leads = zone in ("w", "e") or (
+        zone not in ("n", "s") and abs(w - ref_w) >= abs(h - ref_h) * ratio
+    )
+    if width_leads:
+        w = max(min_w, min(w, bounds[2], bounds[3] * ratio))
+        return w, w / ratio
+    h = max(min_h, min(h, bounds[3], bounds[2] / ratio))
+    return h * ratio, h
+
+
+def _slide_into(
+    box: tuple[float, float, float, float], bounds: Rect
+) -> tuple[float, float, float, float]:
+    """Slide a box inside bounds without changing its shape."""
+    left, top, right, bottom = box
+    bx, by, bw, bh = bounds
+    if left < bx:
+        right += bx - left
+        left = bx
+    if right > bx + bw:
+        left -= right - (bx + bw)
+        right = bx + bw
+    if top < by:
+        bottom += by - top
+        top = by
+    if bottom > by + bh:
+        top -= bottom - (by + bh)
+        bottom = by + bh
+    return (
+        max(bx, left),
+        max(by, top),
+        min(bx + bw, right),
+        min(by + bh, bottom),
+    )
+
+
+def level_delta(dx: float, dy: float) -> float:
+    """Angle to add to level a dragged line.
+
+    The line runs (dx, dy) in display coordinates (y down). Whichever of
+    horizontal or vertical is nearer becomes the target, darktable-style.
+    """
+    if dx == 0.0 and dy == 0.0:
+        return 0.0
+    theta = math.degrees(math.atan2(dy, dx))
+    folded = (theta + 45.0) % 90.0 - 45.0
+    return -folded
+
+
+Line = tuple[float, float, float, float]
+
+# 1/phi: the golden-section split positions are at 1-_PHI_INV and _PHI_INV.
+_PHI_INV = 0.6180339887498949
+_GRID_STEPS = 8
+
+
+def guide_lines(
+    kind: str,
+    w: float,
+    h: float,
+    *,
+    flip_h: bool = False,
+    flip_v: bool = False,
+) -> list[Line]:
+    """Composition guide segments for a crop."""
+    lines = _guide_lines(kind, w, h)
+    if flip_h:
+        lines = [(w - x1, y1, w - x2, y2) for x1, y1, x2, y2 in lines]
+    if flip_v:
+        lines = [(x1, h - y1, x2, h - y2) for x1, y1, x2, y2 in lines]
+    return lines
+
+
+def _guide_lines(kind: str, w: float, h: float) -> list[Line]:
+    """The unmirrored guide segments for a crop."""
+    fractions = {
+        "Thirds": (1 / 3, 2 / 3),
+        "Golden": (1 - _PHI_INV, _PHI_INV),
+        "Center": (0.5,),
+        "Grid": tuple(i / _GRID_STEPS for i in range(1, _GRID_STEPS)),
+    }.get(kind)
+    if fractions is not None:
+        return _section_lines(w, h, fractions)
+    if kind == "Diagonals":
+        m = min(w, h)
+        return [
+            (0.0, 0.0, m, m),
+            (w, 0.0, w - m, m),
+            (0.0, h, m, h - m),
+            (w, h, w - m, h - m),
+        ]
+    if kind == "Triangles":
+        return _triangle_lines(w, h)
+    if kind == "Spiral":
+        return _spiral_lines(w, h)
+    return []
+
+
+def _section_lines(
+    w: float, h: float, fractions: tuple[float, ...]
+) -> list[Line]:
+    """Vertical and horizontal lines at the given width/height fractions."""
+    lines: list[Line] = []
+    for f in fractions:
+        lines.append((w * f, 0.0, w * f, h))
+        lines.append((0.0, h * f, w, h * f))
+    return lines
+
+
+def _triangle_lines(w: float, h: float) -> list[Line]:
+    """Harmonious triangles: the diagonal plus two perpendiculars."""
+    dd = w * w + h * h
+    if dd <= 0:
+        return []
+    lines: list[Line] = [(0.0, 0.0, w, h)]
+    for px, py in ((w, 0.0), (0.0, h)):
+        t = (px * w + py * h) / dd
+        lines.append((px, py, t * w, t * h))
+    return lines
+
+
+def _spiral_lines(w: float, h: float) -> list[Line]:
+    """The golden spiral, stretched to the crop."""
+    if h > w:
+        return [(y1, x1, y2, x2) for x1, y1, x2, y2 in _spiral_lines(h, w)]
+    phi = 1.0 / _PHI_INV
+    x, y, rw, rh = 0.0, 0.0, phi, 1.0
+    points: list[tuple[float, float]] = []
+    for k in range(9):
+        phase = k % 4
+        if phase == 0:
+            s, cx, cy, start = rh, x + rh, y + rh, 180.0
+            nxt = (x + s, y, rw - s, rh)
+        elif phase == 1:
+            s, cx, cy, start = rw, x, y + rw, 270.0
+            nxt = (x, y + s, rw, rh - s)
+        elif phase == 2:  # noqa: PLR2004
+            s, cx, cy, start = rh, x + rw - rh, y, 0.0
+            nxt = (x, y, rw - s, rh)
+        else:
+            s, cx, cy, start = rw, x + rw, y + rh - rw, 90.0
+            nxt = (x, y, rw, rh - s)
+        for i in range(17):
+            ang = math.radians(start + 90.0 * i / 16)
+            points.append((cx + s * math.cos(ang), cy + s * math.sin(ang)))
+        x, y, rw, rh = nxt
+    sx, sy = w / phi, h
+    return [
+        (
+            points[i][0] * sx,
+            points[i][1] * sy,
+            points[i + 1][0] * sx,
+            points[i + 1][1] * sy,
+        )
+        for i in range(len(points) - 1)
+    ]
+
+
+def sidecar_path(raf_path: Path | str) -> Path:
+    """The sidecar path for a RAF: the RAF name plus .grawji.json."""
+    raf = Path(raf_path)
+    return raf.with_name(raf.name + SIDECAR_SUFFIX)
+
+
+def load_sidecar(raf_path: Path | str) -> CropRotate:
+    """Load the RAF's geometry sidecar, or the identity when absent."""
+    path = sidecar_path(raf_path)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return CropRotate()
+    if not isinstance(data, dict) or not isinstance(data.get("crop"), dict):
+        return CropRotate()
+    return CropRotate.from_dict(data["crop"])
+
+
+def save_sidecar(raf_path: Path | str, crop: CropRotate) -> None:
+    """Write the RAF's geometry sidecar, removing it for the identity."""
+    path = sidecar_path(raf_path)
+    try:
+        if crop.is_identity:
+            path.unlink(missing_ok=True)
+        else:
+            path.write_text(
+                json.dumps({"version": 1, "crop": crop.to_dict()}, indent=2),
+                encoding="utf-8",
+            )
+    except OSError as exc:
+        _log.warning("could not write sidecar %s: %s", path, exc)

--- a/src/grawji/settings.py
+++ b/src/grawji/settings.py
@@ -63,6 +63,8 @@ class Settings:
             startup so the tree reopens as it was left.
         last_image: Path of the image selected in the filmstrip, reselected
             on startup when it is still present. Empty means none.
+        crop_guides: Composition guides shown in the crop editor
+            ("None", "Thirds", "Grid", ...).
     """
 
     open_recipe: str = FROM_IMAGE
@@ -81,6 +83,7 @@ class Settings:
     last_export_dir: str = ""
     expanded_folders: list[str] = field(default_factory=list)
     last_image: str = ""
+    crop_guides: str = "Thirds"
 
     def to_dict(self) -> dict[str, object]:
         """Return a plain dict for JSON storage."""

--- a/src/grawji/ui/grawji.cmb
+++ b/src/grawji/ui/grawji.cmb
@@ -2,7 +2,7 @@
 <!DOCTYPE cambalache-project SYSTEM "cambalache-project.dtd">
 <!-- Created with Cambalache 1.0.3 -->
 <cambalache-project version="1.0.0" target_tk="gtk-4.0" depends="libadwaita-1">
-  <ui filename="preview_view.ui" sha256="7bc30eac8d07acbf92f7ff430280d28bc31f495235c2290d680527968432e996"/>
+  <ui filename="preview_view.ui" sha256="a3bb83d312cd40f5709cc223a5393aeec1e2d1ecc08215e3121b27e307a4aa5d"/>
   <ui filename="recipe_panel.ui" sha256="30e5e8c4659cf6b54c0dbce9c2d2eecc69150d6777b3cb03325b5363bc8c2337"/>
   <ui filename="grawji.ui" sha256="5d52074208035ed9d05077a775f46379879b5d8b319524af89b243b709b73a0e"/>
   <ui filename="batch_export.ui" sha256="684f45e4fd429b17511ec6c3dad138195d605a5f3bf6e70491bceec54337273a"/>

--- a/src/grawji/ui/icons/grawji-crop-symbolic.svg
+++ b/src/grawji/ui/icons/grawji-crop-symbolic.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M 3 0 H 5 V 11 H 16 V 13 H 3 Z" fill="#2e3436"/>
+  <path d="M 0 3 H 13 V 16 H 11 V 5 H 0 Z" fill="#2e3436"/>
+</svg>

--- a/src/grawji/ui/preview_view.ui
+++ b/src/grawji/ui/preview_view.ui
@@ -25,6 +25,11 @@
           </object>
         </child>
         <child type="overlay">
+          <object class="GtkDrawingArea" id="crop_overlay">
+            <property name="visible">false</property>
+          </object>
+        </child>
+        <child type="overlay">
           <object class="GtkBox" id="histogram_slot">
             <property name="halign">start</property>
             <property name="valign">end</property>
@@ -32,6 +37,148 @@
             <property name="height-request">110</property>
             <property name="margin-start">10</property>
             <property name="margin-bottom">10</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkRevealer" id="crop_bar">
+        <property name="reveal-child">false</property>
+        <child>
+          <object class="GtkBox">
+            <property name="spacing">6</property>
+            <property name="margin-start">6</property>
+            <property name="margin-end">6</property>
+            <property name="margin-top">4</property>
+            <property name="margin-bottom">4</property>
+            <child>
+              <object class="GtkDropDown" id="crop_aspect">
+                <property name="tooltip-text">Crop aspect ratio</property>
+                <property name="valign">center</property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item>Free</item>
+                      <item>Original</item>
+                      <item>1:1</item>
+                      <item>5:4</item>
+                      <item>4:3</item>
+                      <item>7:5</item>
+                      <item>3:2</item>
+                      <item>16:10</item>
+                      <item>16:9</item>
+                      <item>2:1</item>
+                      <item>65:24</item>
+                    </items>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkToggleButton" id="crop_swap">
+                <property name="icon-name">object-flip-vertical-symbolic</property>
+                <property name="tooltip-text">Swap crop orientation (landscape/portrait)</property>
+                <property name="valign">center</property>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkDropDown" id="crop_guides">
+                <property name="tooltip-text">Composition guides</property>
+                <property name="valign">center</property>
+                <property name="selected">1</property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item>None</item>
+                      <item>Thirds</item>
+                      <item>Grid</item>
+                      <item>Center</item>
+                      <item>Diagonals</item>
+                      <item>Triangles</item>
+                      <item>Golden</item>
+                      <item>Spiral</item>
+                    </items>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkToggleButton" id="guide_flip_h">
+                <property name="icon-name">object-flip-horizontal-symbolic</property>
+                <property name="tooltip-text">Mirror guides horizontally</property>
+                <property name="visible">false</property>
+                <property name="valign">center</property>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkToggleButton" id="guide_flip_v">
+                <property name="icon-name">object-flip-vertical-symbolic</property>
+                <property name="tooltip-text">Mirror guides vertically</property>
+                <property name="visible">false</property>
+                <property name="valign">center</property>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScale" id="angle_scale">
+                <property name="hexpand">true</property>
+                <property name="draw-value">false</property>
+                <property name="tooltip-text">Straighten (drag a line along a horizon with the right mouse button)</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSpinButton" id="angle_spin">
+                <property name="digits">2</property>
+                <property name="valign">center</property>
+                <property name="tooltip-text">Angle in degrees</property>
+                <property name="adjustment">
+                  <object class="GtkAdjustment">
+                    <property name="lower">-45</property>
+                    <property name="upper">45</property>
+                    <property name="step-increment">0.01</property>
+                    <property name="page-increment">1</property>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="crop_reset">
+                <property name="icon-name">edit-undo-symbolic</property>
+                <property name="tooltip-text">Reset crop and angle</property>
+                <property name="valign">center</property>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="crop_cancel">
+                <property name="icon-name">window-close-symbolic</property>
+                <property name="tooltip-text">Cancel (Esc)</property>
+                <property name="valign">center</property>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="crop_apply">
+                <property name="icon-name">object-select-symbolic</property>
+                <property name="tooltip-text">Apply crop (Enter)</property>
+                <property name="valign">center</property>
+                <style>
+                  <class name="suggested-action"/>
+                </style>
+              </object>
+            </child>
           </object>
         </child>
       </object>
@@ -107,6 +254,17 @@
           <object class="GtkButton" id="rotate_right">
             <property name="icon-name">object-rotate-right-symbolic</property>
             <property name="tooltip-text">Rotate right</property>
+            <property name="sensitive">false</property>
+            <property name="valign">center</property>
+            <style>
+              <class name="flat"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkToggleButton" id="crop_button">
+            <property name="icon-name">grawji-crop-symbolic</property>
+            <property name="tooltip-text">Crop and straighten (c)</property>
             <property name="sensitive">false</property>
             <property name="valign">center</property>
             <style>

--- a/src/grawji/views/crop_render.py
+++ b/src/grawji/views/crop_render.py
@@ -1,0 +1,57 @@
+"""Bake CropRotate geometry into pixbuf pixels."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import cairo
+import gi
+
+gi.require_version("Gdk", "4.0")
+
+from gi.repository import Gdk, GdkPixbuf
+
+from grawji.crop import FULL_RECT, CropRotate, rotated_size
+
+_ROTATIONS = {
+    90: GdkPixbuf.PixbufRotation.CLOCKWISE,
+    180: GdkPixbuf.PixbufRotation.UPSIDEDOWN,
+    270: GdkPixbuf.PixbufRotation.COUNTERCLOCKWISE,
+}
+
+
+def orient_pixbuf(pixbuf: Any, orientation: int) -> Any:
+    """Apply a coarse 90-degree orientation to a pixbuf."""
+    rotation = _ROTATIONS.get(orientation)
+    return pixbuf.rotate_simple(rotation) if rotation else pixbuf
+
+
+def bake_pixbuf(pixbuf: Any, crop: CropRotate, *, rect: bool = True) -> Any:
+    """Return pixbuf with the geometry applied to its pixels.
+
+    Args:
+        pixbuf: The exif-oriented source pixbuf.
+        crop: The geometry to apply.
+        rect: When False the crop rect is skipped and the whole rotated
+            frame is returned.
+    """
+    pixbuf = orient_pixbuf(pixbuf, crop.orientation)
+    use_rect = crop.rect if rect else FULL_RECT
+    if crop.angle == 0.0 and use_rect == FULL_RECT:
+        return pixbuf
+    w, h = pixbuf.get_width(), pixbuf.get_height()
+    bw, bh = rotated_size(w, h, crop.angle)
+    x, y, rw, rh = use_rect
+    cw = max(1, round(rw * bw))
+    ch = max(1, round(rh * bh))
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, cw, ch)
+    ctx = cairo.Context(surface)
+    ctx.translate(bw / 2 - x * bw, bh / 2 - y * bh)
+    ctx.rotate(math.radians(crop.angle))
+    ctx.translate(-w / 2, -h / 2)
+    Gdk.cairo_set_source_pixbuf(ctx, pixbuf, 0, 0)
+    ctx.get_source().set_filter(cairo.FILTER_GOOD)
+    ctx.paint()
+    surface.flush()
+    return Gdk.pixbuf_get_from_surface(surface, 0, 0, cw, ch)

--- a/src/grawji/views/dialogs.py
+++ b/src/grawji/views/dialogs.py
@@ -30,6 +30,9 @@ _SHORTCUT_GROUPS = {
         ("Cycle background", "b"),
         ("Show original (before/after)", "backslash"),
         ("Toggle histogram", "h"),
+        ("Crop and straighten", "c"),
+        ("Apply crop", "Return"),
+        ("Cancel crop", "Escape"),
     ],
     "Application": [
         ("Preferences", "<Ctrl>comma"),

--- a/src/grawji/views/export.py
+++ b/src/grawji/views/export.py
@@ -17,14 +17,25 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Gio, GLib, Gtk
 
+from grawji import crop
 from grawji.core import CameraSession, ForeignRafError
 from grawji.preview import CameraWorker
 from grawji.recipe import Recipe
 from grawji.settings import Settings
 from grawji.views import imagemeta
 from grawji.views.batch_export import BatchExportDialog
+from grawji.views.crop_render import bake_pixbuf
+from grawji.views.preview_view import oriented_pixbuf
 
 SetBusy = Callable[..., None]
+
+
+def sidecar_decode(raf_path: str) -> Callable[[bytes], Any] | None:
+    """A decode callback applying the RAF's sidecar geometry, or None."""
+    geometry = crop.load_sidecar(raf_path)
+    if geometry.is_identity:
+        return None
+    return lambda jpeg: bake_pixbuf(oriented_pixbuf(jpeg), geometry)
 
 
 def export_basename(raf_path: Path | str) -> str:
@@ -222,11 +233,7 @@ class BatchController:
         skip_foreign: bool,
         tally: dict[str, int],
     ) -> None:
-        """Convert one RAF into out_path.
-
-        A foreign RAF is skipped (when allowed) and a file-write error is
-        counted so the batch carries on.
-        """
+        """Convert one RAF into out_path."""
         try:
             self._session.open(raf_file)
             jpeg = self._session.render(recipe, full_resolution=True)
@@ -235,9 +242,18 @@ class BatchController:
                 raise
             tally["foreign"] += 1
             return
+        decode = sidecar_decode(raf_file)
         try:
-            out_path.write_bytes(jpeg)
-        except OSError as exc:
+            if decode is None:
+                out_path.write_bytes(jpeg)
+            else:
+                write_jpeg(
+                    jpeg,
+                    str(out_path),
+                    quality=self._settings.jpeg_quality,
+                    decode=decode,
+                )
+        except (GLib.Error, OSError) as exc:
             logging.getLogger("grawji").warning(
                 "batch export could not write %s: %s", out_path, exc
             )

--- a/src/grawji/views/filmstrip.py
+++ b/src/grawji/views/filmstrip.py
@@ -18,6 +18,7 @@ gi.require_version("GExiv2", "0.10")
 
 from gi.repository import Gdk, GdkPixbuf, GExiv2, Gio, GLib, Gtk, Pango
 
+from grawji.crop import sidecar_path
 from grawji.raf import embedded_jpeg, embedded_jpeg_prefix
 from grawji.settings import cache_dir
 
@@ -56,6 +57,14 @@ _ORIENTATIONS = {
 }
 
 
+def _is_raf(gfile: Any) -> bool:
+    """Whether a monitor-event Gio.File refers to a RAF file."""
+    if gfile is None:
+        return False
+    name = gfile.get_basename() or ""
+    return name.lower().endswith(".raf")
+
+
 class FilmStrip(Gtk.ScrolledWindow):
     """A horizontally-scrolling strip of clickable RAF thumbnails."""
 
@@ -89,6 +98,9 @@ class FilmStrip(Gtk.ScrolledWindow):
         self._scan_id = 0
         self._paths: list[str] = []
         self._buttons: list[Gtk.Button] = []
+        self._badges: dict[str, Gtk.Image] = {}
+        self._center_pending: Gtk.Button | None = None
+        self._recenter_id = 0
         self._current = -1
         # Batch-select mode: while active, a click toggles a card's
         # membership in the export set (shown raised) instead of opening it.
@@ -119,15 +131,20 @@ class FilmStrip(Gtk.ScrolledWindow):
         )
         scroll.connect("scroll", self._on_scroll)
         self.add_controller(scroll)
+        self.get_hadjustment().connect("changed", self._on_range_changed)
 
     def scan(self, folder: str) -> None:
         """Populate the strip with the RAF files in folder, and watch it.
 
         The strip re-scans itself automatically (debounced) when the
-        folder's contents change.
+        folder's RAF files change. Re-scanning the same folder keeps
+        the current image selected and in view.
         """
         self._scan_id += 1
         scan_id = self._scan_id
+        keep = None
+        if folder == self._folder and 0 <= self._current < len(self._paths):
+            keep = self._paths[self._current]
         self._clear()
         if self._select_mode:
             # A new folder invalidates any in-progress selection.
@@ -152,6 +169,10 @@ class FilmStrip(Gtk.ScrolledWindow):
             self._box.append(button)
             self._buttons.append(button)
             cards.append((str(path), picture, camera_label))
+
+        if keep is not None and keep in self._paths:
+            # Restore the selection once the new cards have a layout
+            GLib.idle_add(partial(self._restore_current, scan_id, keep))
 
         if cards:
             if self._on_loading is not None:
@@ -182,11 +203,23 @@ class FilmStrip(Gtk.ScrolledWindow):
 
         camera_label = caption("")
         name_label = caption(path.stem)
+        badge = Gtk.Image.new_from_icon_name("grawji-crop-symbolic")
+        badge.set_pixel_size(10)
+        badge.set_halign(Gtk.Align.END)
+        badge.set_valign(Gtk.Align.END)
+        badge.set_margin_end(4)
+        badge.set_margin_bottom(4)
+        badge.set_opacity(0.75)
+        badge.set_tooltip_text("Crop/rotate applied")
+        badge.set_visible(sidecar_path(path).exists())
+        self._badges[str(path)] = badge
+        thumb = Gtk.Overlay(child=picture)
+        thumb.add_overlay(badge)
         card = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=1)
         card.set_margin_top(2)
         card.set_margin_bottom(2)
         card.append(camera_label)
-        card.append(picture)
+        card.append(thumb)
         card.append(name_label)
 
         button = Gtk.Button(child=card)
@@ -213,8 +246,22 @@ class FilmStrip(Gtk.ScrolledWindow):
             self._box.remove(child)
             child = nxt
         self._buttons = []
+        self._badges = {}
+        self._center_pending = None
 
-    def _set_current(self, index: int) -> None:
+    def set_altered(self, path: str, altered: bool) -> None:
+        """Show or hide the geometry badge on path's card."""
+        badge = self._badges.get(path)
+        if badge is not None:
+            badge.set_visible(altered)
+
+    def _restore_current(self, scan_id: int, path: str) -> bool:
+        """Re-select path after a same-folder re-scan (on idle)."""
+        if scan_id == self._scan_id and path in self._paths:
+            self._set_current(self._paths.index(path), center=True)
+        return GLib.SOURCE_REMOVE
+
+    def _set_current(self, index: int, *, center: bool = False) -> None:
         """Mark index as selected and update the highlight."""
         for pos, button in enumerate(self._buttons):
             if pos == index:
@@ -222,22 +269,58 @@ class FilmStrip(Gtk.ScrolledWindow):
             else:
                 button.remove_css_class("thumb-selected")
         self._current = index
+        self._center_pending = None
         if 0 <= index < len(self._buttons):
-            self._scroll_into_view(self._buttons[index])
+            button = self._buttons[index]
+            if center:
+                # Card widths settle while thumbnails load; re-center
+                # on the final layout once this scan finishes.
+                self._center_pending = button
+            self._scroll_into_view(button, center=center)
 
-    def _scroll_into_view(self, button: Gtk.Button) -> None:
+    def _scroll_into_view(
+        self, button: Gtk.Button, retries: int = 20, *, center: bool = False
+    ) -> None:
         """Scroll the strip horizontally so button is visible."""
         adj = self.get_hadjustment()
         ok, rect = button.compute_bounds(self._box)
-        if not ok:
+        if not ok or rect.size.width <= 0 or adj.get_page_size() <= 0:
+            if retries > 0:
+                GLib.timeout_add(
+                    50, self._retry_scroll, button, retries - 1, center
+                )
             return
         left, right = rect.origin.x, rect.origin.x + rect.size.width
         page = adj.get_page_size()
         value = adj.get_value()
-        if left < value:
+        if center:
+            adj.set_value(left - (page - rect.size.width) / 2)
+        elif left < value:
             adj.set_value(left)
         elif right > value + page:
             adj.set_value(right - page)
+
+    def _retry_scroll(
+        self, button: Gtk.Button, retries: int, center: bool
+    ) -> bool:
+        """Re-attempt the scroll once the widget got its layout."""
+        if button.get_parent() is not None:  # card still in the strip
+            self._scroll_into_view(button, retries, center=center)
+        return GLib.SOURCE_REMOVE
+
+    def _on_range_changed(self, _adj: Any) -> None:
+        """Keep a pending restored selection centered through layout."""
+        if self._center_pending is None or self._recenter_id:
+            return
+        self._recenter_id = GLib.timeout_add(10, self._recenter_pending)
+
+    def _recenter_pending(self) -> bool:
+        """Re-center the pending selection after a layout pass."""
+        self._recenter_id = 0
+        button = self._center_pending
+        if button is not None and button.get_parent() is not None:
+            self._scroll_into_view(button, 0, center=True)
+        return GLib.SOURCE_REMOVE
 
     def _on_clicked(self, path: str, _button: Gtk.Button) -> None:
         """Handle a thumbnail click.
@@ -374,7 +457,7 @@ class FilmStrip(Gtk.ScrolledWindow):
         """Select the thumbnail for path. False if it is not in the strip."""
         if path not in self._paths:
             return False
-        self._set_current(self._paths.index(path))
+        self._set_current(self._paths.index(path), center=True)
         self._on_select(path)
         return True
 
@@ -598,8 +681,12 @@ class FilmStrip(Gtk.ScrolledWindow):
         monitor.connect("changed", self._on_folder_changed)
         self._monitor = monitor
 
-    def _on_folder_changed(self, *_args: Any) -> None:
-        """Debounce a re-scan after the folder's contents settle."""
+    def _on_folder_changed(
+        self, _monitor: Any, file: Any, other: Any, _event: Any
+    ) -> None:
+        """Debounce a re-scan when RAF files appear, vanish or move."""
+        if not (_is_raf(file) or _is_raf(other)):
+            return
         if self._reload_pending_id:
             GLib.source_remove(self._reload_pending_id)
         self._reload_pending_id = GLib.timeout_add(

--- a/src/grawji/views/preview_view.py
+++ b/src/grawji/views/preview_view.py
@@ -1,10 +1,13 @@
-"""The preview viewport: zoom, pan, peek, rotation, background, histogram."""
+"""The preview viewport: zoom, pan, peek, crop, background, histogram."""
 
 from __future__ import annotations
 
+import math
+from dataclasses import replace
 from importlib import resources
-from typing import Any
+from typing import Any, ClassVar
 
+import cairo
 import gi
 
 gi.require_version("Gtk", "4.0")
@@ -19,14 +22,30 @@ from gi.repository import (
     Gtk,
 )
 
+from grawji import crop
+from grawji.views.crop_render import bake_pixbuf, orient_pixbuf
 from grawji.views.widgets import Histogram
 
-# Manual rotation (degrees clockwise) -> GdkPixbuf rotation.
-_ROTATIONS = {
-    90: GdkPixbuf.PixbufRotation.CLOCKWISE,
-    180: GdkPixbuf.PixbufRotation.UPSIDEDOWN,
-    270: GdkPixbuf.PixbufRotation.COUNTERCLOCKWISE,
+_ZONE_CURSORS = {
+    "nw": "nwse-resize",
+    "se": "nwse-resize",
+    "ne": "nesw-resize",
+    "sw": "nesw-resize",
+    "n": "ns-resize",
+    "s": "ns-resize",
+    "e": "ew-resize",
+    "w": "ew-resize",
+    "move": "move",
 }
+
+# Handle grab distance on the crop overlay, in pixels.
+_GRAB_PX = 12.0
+
+# A shorter right-button drag than this does not define a horizon.
+_MIN_HORIZON_PX = 4.0
+
+# Longest edge of the image used while crop-editing.
+_EDIT_MAX_EDGE = 2560
 
 # Zoom is multiplicative.
 ZOOM_STEP = 1.15
@@ -44,7 +63,7 @@ _UI = (
 
 
 class _ScaledPaintable(GObject.GObject, Gdk.Paintable):
-    """A texture presented at a chosen intrinsic size, GPU-scaled on draw."""
+    """A paintable presented at a chosen intrinsic size, scaled on draw."""
 
     def __init__(self, texture: Any, width: int, height: int) -> None:
         """Present texture as though it were width x height pixels."""
@@ -122,12 +141,68 @@ class _SplitPaintable(GObject.GObject, Gdk.Paintable):
         )
 
 
-def oriented_pixbuf(jpeg: bytes) -> Any:
-    """Decode JPEG bytes into an EXIF-oriented pixbuf.
+def _capped_copy(pixbuf: Any) -> Any:
+    """A copy of pixbuf whose longest edge is at most _EDIT_MAX_EDGE."""
+    w, h = pixbuf.get_width(), pixbuf.get_height()
+    edge = max(w, h)
+    if edge <= _EDIT_MAX_EDGE:
+        return pixbuf
+    scale = _EDIT_MAX_EDGE / edge
+    return pixbuf.scale_simple(
+        max(1, round(w * scale)),
+        max(1, round(h * scale)),
+        GdkPixbuf.InterpType.BILINEAR,
+    )
 
-    GTK-free so it can run on a worker thread; the result is only
-    attached to widgets back on the main thread.
-    """
+
+class _RotatedPaintable(GObject.GObject, Gdk.Paintable):
+    """A texture drawn fine-rotated, sized as the rotation's bounding box."""
+
+    def __init__(self, texture: Any, width: int, height: int) -> None:
+        """Wrap texture (width x height pixels), initially unrotated."""
+        super().__init__()
+        self._texture = texture
+        self._width = max(1, width)
+        self._height = max(1, height)
+        self._angle = 0.0
+
+    def set_angle(self, angle: float) -> None:
+        """Set the rotation in degrees clockwise and redraw."""
+        if angle == self._angle:
+            return
+        self._angle = angle
+        self.invalidate_size()
+        self.invalidate_contents()
+
+    def _bbox(self) -> tuple[float, float]:
+        """The rotated bounding box of the texture, in texture pixels."""
+        return crop.rotated_size(self._width, self._height, self._angle)
+
+    def do_get_intrinsic_width(self) -> int:
+        """Report the bounding-box width to the layout system."""
+        return max(1, round(self._bbox()[0]))
+
+    def do_get_intrinsic_height(self) -> int:
+        """Report the bounding-box height to the layout system."""
+        return max(1, round(self._bbox()[1]))
+
+    def do_snapshot(self, snapshot: Any, width: float, height: float) -> None:
+        """Draw the texture rotated about the center of the given area."""
+        bw, bh = self._bbox()
+        if bw <= 0 or bh <= 0:
+            return
+        scale = width / bw
+        dw, dh = self._width * scale, self._height * scale
+        snapshot.save()
+        snapshot.translate(Graphene.Point().init(width / 2, height / 2))
+        snapshot.rotate(self._angle)
+        snapshot.translate(Graphene.Point().init(-dw / 2, -dh / 2))
+        self._texture.snapshot(snapshot, dw, dh)
+        snapshot.restore()
+
+
+def oriented_pixbuf(jpeg: bytes) -> Any:
+    """Decode jpeg bytes into an exif-oriented pixbuf."""
     loader = GdkPixbuf.PixbufLoader()
     loader.write(jpeg)
     loader.close()
@@ -138,14 +213,18 @@ def oriented_pixbuf(jpeg: bytes) -> Any:
 class PreviewView(Gtk.Box):
     """The rendered-image viewport plus its status/tool strip.
 
-    Owns everything about presenting a JPEG: zoom (Ctrl+scroll or the
+    Owns everything about presenting a jpeg: zoom (Ctrl+scroll or the
     win.zoom-* actions), drag panning, hold-to-peek at the in-camera
-    original, manual rotation, the cycling canvas background and the
-    histogram overlay. The window feeds it JPEGs and reads back the
-    rotation when exporting.
+    original, crop and straighten, the cycling canvas background and the
+    histogram overlay. The window feeds it jpegs and reads back the
+    geometry when exporting.
     """
 
     __gtype_name__ = "GrawjiPreviewView"
+
+    __gsignals__: ClassVar[dict[str, Any]] = {
+        "geometry-changed": (GObject.SignalFlags.RUN_FIRST, None, ()),
+    }
 
     scroll = Gtk.Template.Child()
     picture = Gtk.Template.Child()
@@ -156,13 +235,43 @@ class PreviewView(Gtk.Box):
     peek_button = Gtk.Template.Child()
     rotate_left = Gtk.Template.Child()
     rotate_right = Gtk.Template.Child()
+    crop_button = Gtk.Template.Child()
+    crop_overlay = Gtk.Template.Child()
+    crop_bar = Gtk.Template.Child()
+    crop_aspect = Gtk.Template.Child()
+    crop_swap = Gtk.Template.Child()
+    crop_guides = Gtk.Template.Child()
+    guide_flip_h = Gtk.Template.Child()
+    guide_flip_v = Gtk.Template.Child()
+    angle_scale = Gtk.Template.Child()
+    angle_spin = Gtk.Template.Child()
+    crop_reset = Gtk.Template.Child()
+    crop_cancel = Gtk.Template.Child()
+    crop_apply = Gtk.Template.Child()
 
     def __init__(self, **kwargs: object) -> None:
-        """Wire the zoom, pan, peek and rotation controllers."""
+        """Wire the zoom, pan, peek and crop controllers."""
         super().__init__(**kwargs)
         self._zoom = 1.0
-        self._rotation = 0
+        self._crop = crop.CropRotate()
+        self._pre_edit = crop.CropRotate()
+        self._editing = False
+        self._edit_closing = False
+        self._syncing_angle = False
+        self._syncing_swap = False
+        self._syncing_aspect = False
+        self._drag_zone: str | None = None
+        self._drag_rect: crop.Rect = crop.FULL_RECT
+        self._hover_zone: str | None = None
+        self._horizon: tuple[float, float, float, float] | None = None
+        self._edit_base: Any | None = None
+        self._edit_base_src: Any | None = None
+        self._edit_texture: Any = None
+        self._edit_texture_size = (0, 0)
+        self._edit_orientation = -1
+        self._edit_paintable: _RotatedPaintable | None = None
         self._pixbuf: Any | None = None
+        self._oriented_pixbuf: Any | None = None
         self._original_pixbuf: Any | None = None
         self._last_jpeg: bytes | None = None
         self._embedded_jpeg: bytes | None = None
@@ -178,7 +287,7 @@ class PreviewView(Gtk.Box):
         self._compare = False
         self._base_jpeg: bytes | None = None
         self._base_pixbuf: Any | None = None
-        self._base_rotation = 0
+        self._base_geometry: crop.CropRotate | None = None
         self._split: _SplitPaintable | None = None
         self._split_fraction = 0.5
         self._dragging_divider = False
@@ -186,12 +295,16 @@ class PreviewView(Gtk.Box):
 
         self.rotate_left.connect("clicked", lambda *_a: self.rotate(-90))
         self.rotate_right.connect("clicked", lambda *_a: self.rotate(90))
+        self._init_crop_controls()
 
         self._histogram = Histogram()
         self._histogram.set_hexpand(True)
         self._histogram.set_vexpand(True)
         self.histogram_slot.append(self._histogram)
+        self._init_viewport_controllers()
 
+    def _init_viewport_controllers(self) -> None:
+        """Wire the zoom, pan, pointer and peek controllers."""
         scroll = Gtk.EventControllerScroll.new(
             Gtk.EventControllerScrollFlags.VERTICAL
         )
@@ -212,6 +325,7 @@ class PreviewView(Gtk.Box):
             self.scroll.get_vadjustment(),
         ):
             adj.connect("changed", self._on_viewport_changed)
+            adj.connect("value-changed", self._on_viewport_scrolled)
 
         peek = Gtk.GestureClick()
         peek.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
@@ -220,10 +334,57 @@ class PreviewView(Gtk.Box):
         peek.connect("cancel", self._on_peek_cancel)
         self.peek_button.add_controller(peek)
 
+    def _init_crop_controls(self) -> None:
+        """Wire the crop bar, the overlay drawing and its gestures."""
+        self.crop_button.connect("toggled", self._on_crop_toggled)
+        self.crop_apply.connect("clicked", lambda *_a: self.apply_crop())
+        self.crop_cancel.connect("clicked", lambda *_a: self.cancel_crop())
+        self.crop_reset.connect("clicked", lambda *_a: self._reset_edit())
+        self._angle_adj = self.angle_spin.get_adjustment()
+        self.angle_scale.set_adjustment(self._angle_adj)
+        self.angle_scale.add_mark(0.0, Gtk.PositionType.BOTTOM, None)
+        self._angle_adj.connect("value-changed", self._on_angle_changed)
+        self.crop_aspect.connect("notify::selected", self._on_aspect_changed)
+        self.crop_swap.connect("toggled", self._on_swap_toggled)
+        self.crop_guides.connect("notify::selected", self._on_guides_selected)
+        for flip in (self.guide_flip_h, self.guide_flip_v):
+            flip.connect("toggled", lambda *_a: self.crop_overlay.queue_draw())
+        self.crop_overlay.set_draw_func(self._draw_crop_overlay)
+
+        drag = Gtk.GestureDrag()
+        drag.connect("drag-begin", self._on_crop_drag_begin)
+        drag.connect("drag-update", self._on_crop_drag_update)
+        drag.connect("drag-end", self._on_crop_drag_end)
+        self.crop_overlay.add_controller(drag)
+        horizon = Gtk.GestureDrag()
+        horizon.set_button(3)
+        horizon.connect("drag-begin", self._on_horizon_begin)
+        horizon.connect("drag-update", self._on_horizon_update)
+        horizon.connect("drag-end", self._on_horizon_end)
+        self.crop_overlay.add_controller(horizon)
+        motion = Gtk.EventControllerMotion.new()
+        motion.connect("motion", self._on_crop_motion)
+        self.crop_overlay.add_controller(motion)
+        wheel = Gtk.EventControllerScroll.new(
+            Gtk.EventControllerScrollFlags.BOTH_AXES
+        )
+        wheel.connect("scroll", self._on_overlay_scroll)
+        self.crop_overlay.add_controller(wheel)
+
     @property
     def rotation(self) -> int:
-        """The manual rotation baked into the display, degrees clockwise."""
-        return self._rotation
+        """The committed 90-degree orientation, degrees clockwise."""
+        return self._crop.orientation
+
+    @property
+    def crop_rotate(self) -> crop.CropRotate:
+        """The current geometry (live values while editing)."""
+        return self._crop
+
+    @property
+    def crop_editing(self) -> bool:
+        """Whether the crop editor is active."""
+        return self._editing
 
     @property
     def peeking(self) -> bool:
@@ -263,16 +424,20 @@ class PreviewView(Gtk.Box):
     def clear_source(self) -> None:
         """Forget the source JPEG (a new selection failed to decode)."""
         self._last_jpeg = None
+        self._oriented_pixbuf = None
 
-    def reset_rotation(self) -> None:
-        """Clear the manual rotation (for a new selection)."""
-        self._rotation = 0
+    def set_crop(self, value: crop.CropRotate) -> None:
+        """Set the committed geometry (for a newly selected image)."""
+        if self._editing:
+            self.cancel_crop()
+        self._crop = value
+        self._invalidate_derived()
 
     def show_jpeg(self, jpeg: bytes) -> bool:
         """Display JPEG bytes in the preview; False if undecodable."""
         self._last_jpeg = jpeg
         try:
-            pixbuf = self.pixbuf_from_jpeg(jpeg)
+            pixbuf = oriented_pixbuf(jpeg)
         except GLib.Error as exc:
             self.set_status(f"Cannot display image: {exc}")
             return False
@@ -280,29 +445,117 @@ class PreviewView(Gtk.Box):
         return True
 
     def show_pixbuf(self, pixbuf: Any, *, jpeg: bytes | None = None) -> None:
-        """Display an already-decoded pixbuf (jpeg is its source bytes)."""
+        """Display an EXIF-oriented pixbuf (jpeg is its source bytes)."""
         if jpeg is not None:
             self._last_jpeg = jpeg
-        self._pixbuf = pixbuf
+        self._oriented_pixbuf = pixbuf
         self._original_pixbuf = None
         self._peek = False
         self.peek_button.set_sensitive(True)
         self.rotate_left.set_sensitive(True)
         self.rotate_right.set_sensitive(True)
-        self._histogram.update(pixbuf)
-        self._refresh_display()
+        self.crop_button.set_sensitive(True)
+        if self._editing:
+            self._conform_crop()
+        self._redisplay()
 
     def pixbuf_from_jpeg(self, jpeg: bytes) -> Any:
-        """Decode JPEG bytes, applying EXIF orientation and rotation."""
-        pixbuf = oriented_pixbuf(jpeg)
-        rotation = _ROTATIONS.get(self._rotation)
-        return pixbuf.rotate_simple(rotation) if rotation else pixbuf
+        """Decode JPEG bytes and bake the current geometry into them."""
+        return bake_pixbuf(oriented_pixbuf(jpeg), self._crop)
 
     def rotate(self, degrees: int) -> None:
-        """Update the rotation and redisplay the current image."""
-        self._rotation = (self._rotation + degrees) % 360
-        if self._last_jpeg is not None:
-            self.show_jpeg(self._last_jpeg)
+        """Turn the image by a 90-degree step and redisplay."""
+        current = self._crop
+        self._crop = replace(
+            current,
+            orientation=(current.orientation + degrees) % 360,
+            rect=crop.rotate_rect_90(current.rect, degrees),
+        )
+        self._invalidate_derived()
+        self._redisplay()
+        if not self._editing:
+            self.emit("geometry-changed")
+
+    def _invalidate_derived(self) -> None:
+        """Drop pixbufs derived under a now-stale geometry."""
+        self._original_pixbuf = None
+        self._base_pixbuf = None
+
+    def _redisplay(self, *, histogram: bool = True) -> None:
+        """Recompute the displayed image from the oriented source."""
+        if self._oriented_pixbuf is None:
+            return
+        if not self._editing:
+            display = bake_pixbuf(self._oriented_pixbuf, self._crop)
+            self._pixbuf = display
+            if histogram:
+                self._histogram.update(display)
+        self._refresh_display()
+        self.crop_overlay.queue_draw()
+
+    def _edit_display_paintable(self) -> _RotatedPaintable | None:
+        """The GPU-rotated paintable for the crop editor."""
+        if self._oriented_pixbuf is None:
+            return None
+        if self._edit_base_src is not self._oriented_pixbuf:
+            self._edit_base = _capped_copy(self._oriented_pixbuf)
+            self._edit_base_src = self._oriented_pixbuf
+            self._edit_texture = None
+        if (
+            self._edit_texture is None
+            or self._edit_orientation != self._crop.orientation
+        ):
+            pixbuf = orient_pixbuf(self._edit_base, self._crop.orientation)
+            self._edit_texture = Gdk.Texture.new_for_pixbuf(pixbuf)
+            self._edit_texture_size = (
+                pixbuf.get_width(),
+                pixbuf.get_height(),
+            )
+            self._edit_orientation = self._crop.orientation
+            self._edit_paintable = None
+        if self._edit_paintable is None:
+            self._edit_paintable = _RotatedPaintable(
+                self._edit_texture, *self._edit_texture_size
+            )
+        self._edit_paintable.set_angle(self._crop.angle)
+        return self._edit_paintable
+
+    def _drop_edit_display(self) -> None:
+        """Free the crop editor's texture and caches."""
+        self._edit_base = None
+        self._edit_base_src = None
+        self._edit_texture = None
+        self._edit_orientation = -1
+        self._edit_paintable = None
+
+    def _apply_edit_view(self) -> None:
+        """Present the crop editor's GPU-rotated view at the zoom."""
+        paintable = self._edit_display_paintable()
+        dims = self._display_dims()
+        if paintable is None or dims is None:
+            return
+        self._split = None
+        pw, ph = dims
+        vw = self.scroll.get_width() or pw
+        vh = self.scroll.get_height() or ph
+        if self._zoom == 1.0:
+            self.picture.set_can_shrink(True)
+            self.picture.set_halign(Gtk.Align.FILL)
+            self.picture.set_valign(Gtk.Align.FILL)
+            self.picture.set_paintable(paintable)
+            self._content_w, self._content_h = float(vw), float(vh)
+        else:
+            fit = min(vw / pw, vh / ph)
+            sw = max(1, int(pw * fit * self._zoom))
+            sh = max(1, int(ph * fit * self._zoom))
+            self.picture.set_can_shrink(False)
+            self.picture.set_halign(Gtk.Align.CENTER)
+            self.picture.set_valign(Gtk.Align.CENTER)
+            self.picture.set_paintable(_ScaledPaintable(paintable, sw, sh))
+            self._content_w, self._content_h = float(sw), float(sh)
+        self._shown_size = (pw, ph)
+        self._update_zoom_label()
+        self.crop_overlay.queue_draw()
 
     def zoom_in(self) -> None:
         """Zoom in one step, centred on the viewport."""
@@ -339,10 +592,11 @@ class PreviewView(Gtk.Box):
         self._anchor_scroll(vadj, fy, ay, self._content_h, vh)
 
     def _fit_scale(self) -> float | None:
-        """The fit-to-viewport scale of the current image, native = 1.0."""
-        if self._pixbuf is None:
+        """The fit-to-viewport scale of the shown image, native = 1.0."""
+        dims = self._display_dims()
+        if dims is None:
             return None
-        pw, ph = self._pixbuf.get_width(), self._pixbuf.get_height()
+        pw, ph = dims
         vw, vh = self.scroll.get_width(), self.scroll.get_height()
         if pw <= 0 or ph <= 0 or vw <= 0 or vh <= 0:
             return None
@@ -350,6 +604,8 @@ class PreviewView(Gtk.Box):
 
     def set_peek(self, *, peeking: bool) -> None:
         """Show the in-camera original while peeking, else the result."""
+        if peeking and self._editing:
+            return
         if peeking and self._original_pixbuf is None:
             if self._embedded_jpeg is None:
                 return
@@ -375,15 +631,15 @@ class PreviewView(Gtk.Box):
             self._refresh_display()
 
     def _base_for_rotation(self) -> Any | None:
-        """The baseline pixbuf decoded at the current rotation (cached)."""
+        """The baseline pixbuf decoded at the current geometry."""
         if self._base_jpeg is None:
             return None
-        if self._base_pixbuf is None or self._base_rotation != self._rotation:
+        if self._base_pixbuf is None or self._base_geometry != self._crop:
             try:
                 self._base_pixbuf = self.pixbuf_from_jpeg(self._base_jpeg)
             except GLib.Error:
                 return None
-            self._base_rotation = self._rotation
+            self._base_geometry = self._crop
         return self._base_pixbuf
 
     def set_compare(self, *, on: bool) -> bool:
@@ -416,7 +672,7 @@ class PreviewView(Gtk.Box):
     def _on_peek_pressed(
         self, gesture: Gtk.GestureClick, _n: int, _x: float, _y: float
     ) -> None:
-        """Start peeking; claim the press so the button does not cancel it."""
+        """Start peeking. Claim the press so the button does not cancel it."""
         gesture.set_state(Gtk.EventSequenceState.CLAIMED)
         self.set_peek(peeking=True)
 
@@ -525,6 +781,11 @@ class PreviewView(Gtk.Box):
         self.set_zoom(self._zoom * factor, anchor=self._pointer)
         return True
 
+    def _on_viewport_scrolled(self, _adj: Any) -> None:
+        """Keep the crop overlay glued to the image while panning."""
+        if self._editing:
+            self.crop_overlay.queue_draw()
+
     def _on_viewport_changed(self, _adj: Any) -> None:
         """Refresh the zoom readout when the viewport geometry changes."""
         self._update_zoom_label()
@@ -572,7 +833,11 @@ class PreviewView(Gtk.Box):
 
     def _apply_zoom(self) -> None:
         """Show the preview at the current zoom (split view when comparing)."""
-        base_pixbuf = self._base_for_rotation() if self._compare else None
+        if self._editing:
+            self._apply_edit_view()
+            return
+        comparing_now = self._compare and not self._editing
+        base_pixbuf = self._base_for_rotation() if comparing_now else None
         comparing = base_pixbuf is not None
         pixbuf = self._pixbuf if comparing else self._preview_pixbuf()
         if pixbuf is None:
@@ -622,3 +887,481 @@ class PreviewView(Gtk.Box):
         self._content_w, self._content_h = sw, sh
         self._shown_size = (pw, ph)
         self._update_zoom_label()
+
+    def _on_crop_toggled(self, button: Any) -> None:
+        """Enter the crop editor, or commit it when toggled back off."""
+        if self._edit_closing:
+            return
+        if button.get_active():
+            if not self._start_edit():
+                self._set_crop_toggle(active=False)
+        else:
+            self.apply_crop()
+
+    def _set_crop_toggle(self, *, active: bool) -> None:
+        """Sync the toolbar toggle without re-entering its handler."""
+        self._edit_closing = True
+        self.crop_button.set_active(active)
+        self._edit_closing = False
+
+    def _start_edit(self) -> bool:
+        """Open the crop editor on the current image."""
+        if self._editing or self._oriented_pixbuf is None:
+            return self._editing
+        self._pre_edit = self._crop
+        self.zoom_fit()
+        self._editing = True
+        self._select_aspect(self._crop.aspect)
+        self._sync_swap(active=self._crop.aspect_swapped)
+        self._conform_crop()
+        self._sync_angle(self._crop.angle)
+        self.crop_bar.set_reveal_child(True)
+        self.crop_overlay.set_visible(True)
+        self._redisplay(histogram=False)
+        return True
+
+    def _conform_crop(self) -> None:
+        """Shrink the crop rect onto the current image if it strays."""
+        dims = self._oriented_dims()
+        if dims is None:
+            return
+        rect = crop.shrink_to_fit(
+            dims[0], dims[1], self._crop.angle, self._crop.rect
+        )
+        if rect != self._crop.rect:
+            self._crop = replace(self._crop, rect=rect)
+            self.crop_overlay.queue_draw()
+
+    def apply_crop(self) -> None:
+        """Commit the crop edit (Enter, the check button or the toggle)."""
+        self._finish_edit(apply=True)
+
+    def cancel_crop(self) -> None:
+        """Abandon the crop edit and restore the previous geometry."""
+        self._finish_edit(apply=False)
+
+    def _finish_edit(self, *, apply: bool) -> None:
+        """Leave the crop editor, keeping or reverting its changes."""
+        if not self._editing:
+            return
+        self._editing = False
+        if not apply:
+            self._crop = self._pre_edit
+        self._horizon = None
+        self.crop_bar.set_reveal_child(False)
+        self.crop_overlay.set_visible(False)
+        self._set_crop_toggle(active=False)
+        self._invalidate_derived()
+        self._drop_edit_display()
+        self._redisplay()
+        if apply and self._crop != self._pre_edit:
+            self.emit("geometry-changed")
+
+    def _reset_edit(self) -> None:
+        """Reset the editor to the untouched state."""
+        if not self._editing:
+            return
+        self._crop = replace(
+            self._crop,
+            angle=0.0,
+            rect=crop.FULL_RECT,
+            aspect="Original",
+            aspect_swapped=False,
+        )
+        self._select_aspect("Original")
+        self._sync_swap(active=False)
+        self._sync_angle(0.0)
+        self._redisplay(histogram=False)
+
+    def _sync_angle(self, value: float) -> None:
+        """Move the angle controls without re-applying the angle."""
+        self._syncing_angle = True
+        self._angle_adj.set_value(value)
+        self._syncing_angle = False
+
+    def _on_angle_changed(self, adj: Any) -> None:
+        """Apply a new angle from the slider or spin button."""
+        if self._syncing_angle or not self._editing:
+            return
+        self._set_angle(adj.get_value())
+
+    def _oriented_dims(self) -> tuple[int, int] | None:
+        """The image size in pixels after the 90-degree orientation."""
+        if self._oriented_pixbuf is None:
+            return None
+        w = self._oriented_pixbuf.get_width()
+        h = self._oriented_pixbuf.get_height()
+        if self._crop.orientation in (90, 270):
+            return h, w
+        return w, h
+
+    def _set_angle(self, angle: float) -> None:
+        """Re-rotate to angle, carrying the crop rect along."""
+        dims = self._oriented_dims()
+        if dims is None:
+            return
+        w, h = dims
+        old = self._crop
+        obw, obh = crop.rotated_size(w, h, old.angle)
+        nbw, nbh = crop.rotated_size(w, h, angle)
+        x, y, rw, rh = old.rect
+        # Keep the crop's pixel size and its offset from the image
+        # center while the bounding box changes, then shrink to fit.
+        ccx = (x + rw / 2 - 0.5) * obw
+        ccy = (y + rh / 2 - 0.5) * obh
+        nw = rw * obw / nbw
+        nh = rh * obh / nbh
+        nx = 0.5 + ccx / nbw - nw / 2
+        ny = 0.5 + ccy / nbh - nh / 2
+        rect = crop.shrink_to_fit(w, h, angle, (nx, ny, nw, nh))
+        self._crop = replace(old, angle=angle, rect=rect)
+        self._redisplay(histogram=False)
+
+    @property
+    def guides_name(self) -> str:
+        """The selected composition-guide kind."""
+        item = self.crop_guides.get_selected_item()
+        return item.get_string() if item is not None else "Thirds"
+
+    def set_crop_guides(self, name: str) -> None:
+        """Select the composition guides by name."""
+        model = self.crop_guides.get_model()
+        index = 1  # Thirds
+        for i in range(model.get_n_items()):
+            if model.get_string(i) == name:
+                index = i
+                break
+        self.crop_guides.set_selected(index)
+        self._update_guide_flips()
+
+    def _on_guides_selected(self, *_args: object) -> None:
+        """Redraw for the new guides and show the flips only if useful."""
+        self._update_guide_flips()
+        self.crop_overlay.queue_draw()
+
+    def _update_guide_flips(self) -> None:
+        """Show the mirror toggles only for chiral guides."""
+        chiral = self.guides_name in ("Spiral", "Triangles")
+        self.guide_flip_h.set_visible(chiral)
+        self.guide_flip_v.set_visible(chiral)
+
+    def _aspect_label(self) -> str:
+        """The aspect dropdown's current label."""
+        item = self.crop_aspect.get_selected_item()
+        return item.get_string() if item is not None else "Free"
+
+    def _select_aspect(self, label: str) -> None:
+        """Move the aspect dropdown without re-shaping the selection."""
+        model = self.crop_aspect.get_model()
+        index = 0
+        for i in range(model.get_n_items()):
+            if model.get_string(i) == label:
+                index = i
+                break
+        self._syncing_aspect = True
+        self.crop_aspect.set_selected(index)
+        self._syncing_aspect = False
+
+    def _aspect_ratio_px(self) -> float | None:
+        """The selected crop aspect as pixel width over height, or None."""
+        label = self._aspect_label()
+        if label == "Free":
+            ratio = None
+        elif label == "Original":
+            dims = self._oriented_dims()
+            ratio = dims[0] / dims[1] if dims is not None else None
+        else:
+            a, b = label.split(":")
+            ratio = float(a) / float(b)
+        if ratio is not None and self.crop_swap.get_active():
+            return 1.0 / ratio
+        return ratio
+
+    def _on_swap_toggled(self, _button: Any) -> None:
+        """Rotate the selection between landscape and portrait."""
+        if self._syncing_swap or not self._editing:
+            return
+        self._crop = replace(
+            self._crop, aspect_swapped=self.crop_swap.get_active()
+        )
+        dims = self._oriented_dims()
+        if dims is None:
+            return
+        w, h = dims
+        rect = crop.swap_rect(w, h, self._crop.angle, self._crop.rect)
+        self._crop = replace(self._crop, rect=rect)
+        self.crop_overlay.queue_draw()
+
+    def _sync_swap(self, *, active: bool) -> None:
+        """Move the swap toggle without re-shaping the selection."""
+        self._syncing_swap = True
+        self.crop_swap.set_active(active)
+        self._syncing_swap = False
+
+    def _on_aspect_changed(self, *_args: object) -> None:
+        """Remember the choice and re-shape the crop rect to it."""
+        if self._syncing_aspect or not self._editing:
+            return
+        self._crop = replace(self._crop, aspect=self._aspect_label())
+        ratio = self._aspect_ratio_px()
+        dims = self._oriented_dims()
+        if ratio is None or dims is None:
+            return
+        w, h = dims
+        current = self._crop
+        bw, bh = crop.rotated_size(w, h, current.angle)
+        x, y, rw, rh = current.rect
+        # Keep the center and roughly the area, in pixels.
+        area = (rw * bw) * (rh * bh)
+        pw = math.sqrt(area * ratio)
+        ph = pw / ratio
+        scale = min(1.0, bw / pw, bh / ph)
+        nw = pw * scale / bw
+        nh = ph * scale / bh
+        nx = min(max(x + rw / 2 - nw / 2, 0.0), 1.0 - nw)
+        ny = min(max(y + rh / 2 - nh / 2, 0.0), 1.0 - nh)
+        rect = crop.shrink_to_fit(w, h, current.angle, (nx, ny, nw, nh))
+        self._crop = replace(current, rect=rect)
+        self.crop_overlay.queue_draw()
+
+    def _display_dims(self) -> tuple[int, int] | None:
+        """Logical pixel size of what the picture currently displays."""
+        if self._editing:
+            dims = self._oriented_dims()
+            if dims is None:
+                return None
+            bw, bh = crop.rotated_size(dims[0], dims[1], self._crop.angle)
+            return max(1, round(bw)), max(1, round(bh))
+        if self._pixbuf is None:
+            return None
+        return self._pixbuf.get_width(), self._pixbuf.get_height()
+
+    def _display_bounds(self) -> tuple[float, float, float, float] | None:
+        """The drawn image in crop-overlay coordinates."""
+        dims = self._display_dims()
+        if dims is None:
+            return None
+        iw, ih = dims
+        ok, rect = self.picture.compute_bounds(self.crop_overlay)
+        if not ok or iw <= 0 or ih <= 0:
+            return None
+        if rect.size.width <= 0 or rect.size.height <= 0:
+            return None
+        scale = min(rect.size.width / iw, rect.size.height / ih)
+        dw, dh = iw * scale, ih * scale
+        if dw <= 0 or dh <= 0:
+            return None
+        return (
+            rect.origin.x + (rect.size.width - dw) / 2,
+            rect.origin.y + (rect.size.height - dh) / 2,
+            dw,
+            dh,
+        )
+
+    def _pointer_zone(self, x: float, y: float) -> str | None:
+        """The crop drag zone under an overlay-coordinate pointer."""
+        bounds = self._display_bounds()
+        if bounds is None:
+            return None
+        ox, oy, dw, dh = bounds
+        return crop.hit_zone(
+            self._crop.rect,
+            (x - ox) / dw,
+            (y - oy) / dh,
+            _GRAB_PX / dw,
+            _GRAB_PX / dh,
+        )
+
+    def _on_overlay_scroll(
+        self, controller: Any, dx: float, dy: float
+    ) -> bool:
+        """Zoom or pan the view from a wheel over the editor."""
+        event = controller.get_current_event()
+        state = event.get_modifier_state() if event else 0
+        if state & Gdk.ModifierType.CONTROL_MASK:
+            factor = ZOOM_STEP if dy < 0 else 1 / ZOOM_STEP
+            self.set_zoom(self._zoom * factor, anchor=self._pointer)
+            return True
+        if state & Gdk.ModifierType.SHIFT_MASK:
+            dx, dy = dy, dx
+        step = 60.0
+        hadj = self.scroll.get_hadjustment()
+        vadj = self.scroll.get_vadjustment()
+        hadj.set_value(hadj.get_value() + dx * step)
+        vadj.set_value(vadj.get_value() + dy * step)
+        return True
+
+    def _on_crop_drag_begin(self, _gesture: Any, x: float, y: float) -> None:
+        """Grab a handle, an edge, the rect body, or start a pan."""
+        self._drag_zone = self._pointer_zone(x, y)
+        self._drag_rect = self._crop.rect
+        if self._drag_zone is None:
+            self._pan_h = self.scroll.get_hadjustment().get_value()
+            self._pan_v = self.scroll.get_vadjustment().get_value()
+
+    def _on_crop_drag_update(
+        self, _gesture: Any, dx: float, dy: float
+    ) -> None:
+        """Resize or move the crop rect, constrained to image pixels."""
+        if self._drag_zone is None:
+            self.scroll.get_hadjustment().set_value(self._pan_h - dx)
+            self.scroll.get_vadjustment().set_value(self._pan_v - dy)
+            return
+        bounds = self._display_bounds()
+        dims = self._oriented_dims()
+        if bounds is None or dims is None:
+            return
+        _ox, _oy, dw, dh = bounds
+        w, h = dims
+        angle = self._crop.angle
+        ratio = self._aspect_ratio_px()
+        nratio = None
+        if ratio is not None:
+            bw, bh = crop.rotated_size(w, h, angle)
+            nratio = ratio * bh / bw
+        rect = crop.constrain_drag(
+            w,
+            h,
+            angle,
+            self._drag_rect,
+            self._drag_zone,
+            dx=dx / dw,
+            dy=dy / dh,
+            ratio=nratio,
+        )
+        self._crop = replace(self._crop, rect=rect)
+        self.crop_overlay.queue_draw()
+
+    def _on_crop_drag_end(self, _gesture: Any, _dx: float, _dy: float) -> None:
+        """Release the dragged handle."""
+        self._drag_zone = None
+
+    def _on_horizon_begin(self, _gesture: Any, x: float, y: float) -> None:
+        """Start drawing the straighten line."""
+        self._horizon = (x, y, x, y)
+        self.crop_overlay.queue_draw()
+
+    def _on_horizon_update(self, gesture: Any, dx: float, dy: float) -> None:
+        """Track the straighten line under the pointer."""
+        ok, sx, sy = gesture.get_start_point()
+        if not ok:
+            return
+        self._horizon = (sx, sy, sx + dx, sy + dy)
+        self.crop_overlay.queue_draw()
+
+    def _on_horizon_end(self, _gesture: Any, dx: float, dy: float) -> None:
+        """Level the image to the drawn line."""
+        self._horizon = None
+        if abs(dx) < _MIN_HORIZON_PX and abs(dy) < _MIN_HORIZON_PX:
+            self.crop_overlay.queue_draw()
+            return
+        angle = self._crop.angle + crop.level_delta(dx, dy)
+        angle = max(-crop.MAX_ANGLE, min(crop.MAX_ANGLE, angle))
+        self._sync_angle(angle)
+        self._set_angle(angle)
+
+    def _horizon_off_degrees(self, dx: float, dy: float) -> float:
+        """The drawn line's on-screen tilt in degrees."""
+        return -crop.level_delta(dx, dy)
+
+    def _on_crop_motion(self, _controller: Any, x: float, y: float) -> None:
+        """Track the pointer and show the zone cursor."""
+        self._pointer = (x, y)
+        zone = self._pointer_zone(x, y)
+        if zone == self._hover_zone:
+            return
+        self._hover_zone = zone
+        name = _ZONE_CURSORS.get(zone or "")
+        self.crop_overlay.set_cursor(
+            Gdk.Cursor.new_from_name(name, None) if name else None
+        )
+
+    def _draw_crop_overlay(
+        self, _area: Any, ctx: Any, width: int, height: int
+    ) -> None:
+        """Draw the dimmed surround, guides, handles and horizon line."""
+        if not self._editing:
+            return
+        bounds = self._display_bounds()
+        if bounds is None:
+            return
+        ox, oy, dw, dh = bounds
+        x, y, w, h = self._crop.rect
+        rx, ry = ox + x * dw, oy + y * dh
+        rw, rh = w * dw, h * dh
+        # Dim everything outside the crop rect.
+        ctx.set_fill_rule(cairo.FILL_RULE_EVEN_ODD)
+        ctx.set_source_rgba(0, 0, 0, 0.45)
+        ctx.rectangle(ox, oy, dw, dh)
+        ctx.rectangle(rx, ry, rw, rh)
+        ctx.fill()
+        # Composition guides (selectable, darktable-style).
+        ctx.set_line_width(1.0)
+        ctx.set_source_rgba(1, 1, 1, 0.35)
+        lines = crop.guide_lines(
+            self.guides_name,
+            rw,
+            rh,
+            flip_h=self.guide_flip_h.get_active(),
+            flip_v=self.guide_flip_v.get_active(),
+        )
+        for x1, y1, x2, y2 in lines:
+            ctx.move_to(rx + x1, ry + y1)
+            ctx.line_to(rx + x2, ry + y2)
+        ctx.stroke()
+        # The rect border: a dark halo under a white line.
+        ctx.set_source_rgba(0, 0, 0, 0.6)
+        ctx.set_line_width(3.0)
+        ctx.rectangle(rx, ry, rw, rh)
+        ctx.stroke()
+        ctx.set_source_rgba(1, 1, 1, 0.9)
+        ctx.set_line_width(1.0)
+        ctx.rectangle(rx, ry, rw, rh)
+        ctx.stroke()
+        # Corner and edge handles.
+        ctx.set_source_rgba(1, 1, 1, 0.95)
+        half = 4.0
+        for hx in (rx, rx + rw / 2, rx + rw):
+            for hy in (ry, ry + rh / 2, ry + rh):
+                if hx == rx + rw / 2 and hy == ry + rh / 2:
+                    continue
+                ctx.rectangle(hx - half, hy - half, half * 2, half * 2)
+        ctx.fill()
+        if self._horizon is not None:
+            self._draw_horizon(ctx, width, height)
+
+    def _draw_horizon(self, ctx: Any, width: int, height: int) -> None:
+        """Draw the straighten line plus its off-level degree readout."""
+        if self._horizon is None:
+            return
+        x0, y0, x1, y1 = self._horizon
+        ctx.set_source_rgba(1.0, 0.8, 0.2, 0.9)
+        ctx.set_line_width(2.0)
+        ctx.move_to(x0, y0)
+        ctx.line_to(x1, y1)
+        ctx.stroke()
+        for ex, ey in ((x0, y0), (x1, y1)):
+            ctx.arc(ex, ey, 3.0, 0.0, 2.0 * math.pi)
+            ctx.stroke()
+        dx, dy = x1 - x0, y1 - y0
+        if abs(dx) < _MIN_HORIZON_PX and abs(dy) < _MIN_HORIZON_PX:
+            return
+        label = f"{self._horizon_off_degrees(dx, dy):.2f}°"
+        ctx.set_font_size(13.0)
+        ext = ctx.text_extents(label)
+        pad = 5.0
+        tx = x1 + 16.0
+        ty = y1 - 16.0
+        tx = min(max(tx, pad), width - ext.width - 2 * pad)
+        ty = min(max(ty, ext.height + 2 * pad), height - pad)
+        ctx.set_source_rgba(0, 0, 0, 0.65)
+        ctx.rectangle(
+            tx - pad,
+            ty - ext.height - pad,
+            ext.width + 2 * pad,
+            ext.height + 2 * pad,
+        )
+        ctx.fill()
+        ctx.set_source_rgba(1, 1, 1, 0.95)
+        ctx.move_to(tx - ext.x_bearing, ty)
+        ctx.show_text(label)

--- a/src/grawji/views/window.py
+++ b/src/grawji/views/window.py
@@ -18,7 +18,7 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Adw, Gdk, Gio, GLib, Gtk
 
-from grawji import camera_info, raf
+from grawji import camera_info, crop, raf
 from grawji.capabilities import (
     Capabilities,
     capabilities_for,
@@ -150,10 +150,9 @@ class MainWindow(Adw.ApplicationWindow):
                 self._settings.window_width, self._settings.window_height
             )
         self._init_sidebar()
-        self._install_css()
+        self._install_assets()
 
-        self.preview_view.set_background(self._settings.canvas_background)
-        self.preview_view.set_show_histogram(self._settings.show_histogram)
+        self._init_preview_wiring()
         self.recipe_panel.set_wb_grid_tint(self._settings.wb_grid_tint)
         self.recipe_panel.connect("changed", self._on_recipe_changed)
         self.recipe_panel.connect("apply-recipe", self._on_apply_recipe)
@@ -238,6 +237,7 @@ class MainWindow(Adw.ApplicationWindow):
             ("zoom-fit", view.zoom_fit, ("<Ctrl>0",)),
             ("cycle-background", self._cycle_background, ("b",)),
             ("toggle-peek", self._toggle_peek, ("backslash",)),
+            ("toggle-crop", self._toggle_crop, ("c",)),
             (
                 "shortcuts",
                 lambda: dialogs.present_shortcuts(self),
@@ -305,6 +305,27 @@ class MainWindow(Adw.ApplicationWindow):
         else:
             self.main_paned.set_position(self._sidebar_expanded_width)
 
+    def _init_preview_wiring(self) -> None:
+        """Apply preview settings and hook up its crop editor."""
+        self.preview_view.set_background(self._settings.canvas_background)
+        self.preview_view.set_show_histogram(self._settings.show_histogram)
+        self.preview_view.connect(
+            "geometry-changed", self._on_geometry_changed
+        )
+        self.preview_view.set_crop_guides(self._settings.crop_guides)
+        self.preview_view.crop_guides.connect(
+            "notify::selected", self._on_guides_changed
+        )
+        crop_keys = Gtk.EventControllerKey.new()
+        crop_keys.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
+        crop_keys.connect("key-pressed", self._on_crop_key)
+        self.add_controller(crop_keys)
+
+    def _install_assets(self) -> None:
+        """Install display-wide assets: the app CSS and bundled icons."""
+        self._install_css()
+        self._install_icons()
+
     def _install_css(self) -> None:
         """Load the app's CSS for the preview canvas and thumbnails."""
         provider = Gtk.CssProvider()
@@ -314,6 +335,17 @@ class MainWindow(Adw.ApplicationWindow):
             provider,
             Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
         )
+
+    def _install_icons(self) -> None:
+        """Register grawji's bundled icons with the icon theme.
+
+        Symbolic icons no theme reliably ships (e.g. the crop glyph)
+        are looked up from the package's ui/icons directory instead.
+        """
+        icons = resources.files("grawji").joinpath("ui", "icons")
+        Gtk.IconTheme.get_for_display(
+            Gdk.Display.get_default()
+        ).add_search_path(str(icons))
 
     def _init_filmstrip(self) -> None:
         """Build the filmstrip flanked by previous/next navigation."""
@@ -373,7 +405,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._load_pending_id = 0
         if generation != self._generation:
             return GLib.SOURCE_REMOVE
-        self.preview_view.reset_rotation()
+        self.preview_view.set_crop(crop.load_sidecar(raf_path))
         # The camera open runs on its own worker. The embedded-preview read
         # and decode run on a short-lived thread. Neither blocks the UI, so
         # the filmstrip animation stays smooth and the image appears as soon
@@ -719,6 +751,40 @@ class MainWindow(Adw.ApplicationWindow):
     def _toggle_peek(self) -> None:
         """Toggle showing the in-camera original."""
         self.preview_view.set_peek(peeking=not self.preview_view.peeking)
+
+    def _toggle_crop(self) -> None:
+        """Open the crop editor, or commit it if it is already open."""
+        button = self.preview_view.crop_button
+        if button.get_sensitive():
+            button.set_active(not button.get_active())
+
+    def _on_crop_key(
+        self, _controller: Any, keyval: int, _code: int, _state: Any
+    ) -> bool:
+        """Finish the crop edit from the keyboard."""
+        if not self.preview_view.crop_editing:
+            return False
+        if keyval == Gdk.KEY_Escape:
+            self.preview_view.cancel_crop()
+            return True
+        if keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
+            self.preview_view.apply_crop()
+            return True
+        return False
+
+    def _on_guides_changed(self, *_args: object) -> None:
+        """Remember the chosen composition guides."""
+        self._settings.crop_guides = self.preview_view.guides_name
+        self._save_settings()
+
+    def _on_geometry_changed(self, _view: Any) -> None:
+        """Persist a committed crop/rotation to the RAF's sidecar."""
+        if self._raf_path is None:
+            return
+        crop.save_sidecar(self._raf_path, self.preview_view.crop_rotate)
+        self._filmstrip.set_altered(
+            str(self._raf_path), crop.sidecar_path(self._raf_path).exists()
+        )
 
     def _populate_exif_rows(self, rows: list[tuple[str, str]]) -> None:
         """Show already-parsed EXIF (label, value) pairs in the Image group."""

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -1,0 +1,439 @@
+"""Tests for the pure crop/rotate geometry and its sidecar IO."""
+
+from __future__ import annotations
+
+import itertools
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from grawji.crop import (
+    FULL_RECT,
+    CropRotate,
+    apply_drag,
+    clamp_move,
+    constrain_drag,
+    fits,
+    guide_lines,
+    hit_zone,
+    largest_fit,
+    level_delta,
+    load_sidecar,
+    rotate_rect_90,
+    rotated_size,
+    save_sidecar,
+    shrink_to_fit,
+    sidecar_path,
+    swap_rect,
+)
+
+
+def test_identity() -> None:
+    """A default CropRotate changes nothing."""
+    assert CropRotate().is_identity
+    assert not CropRotate(orientation=90).is_identity
+    assert not CropRotate(angle=1.0).is_identity
+    assert not CropRotate(rect=(0.1, 0.1, 0.8, 0.8)).is_identity
+
+
+def test_dict_round_trip() -> None:
+    """to_dict/from_dict preserve values and ignore extras."""
+    value = CropRotate(
+        orientation=180,
+        angle=-3.5,
+        rect=(0.1, 0.2, 0.5, 0.4),
+        aspect="1:1",
+        aspect_swapped=True,
+    )
+    data = value.to_dict()
+    data["future_field"] = "ignored"
+    assert CropRotate.from_dict(data) == value
+
+
+def test_from_dict_sanitizes() -> None:
+    """Broken stored values fall back to safe defaults."""
+    assert CropRotate.from_dict({"orientation": 45}).orientation == 0
+    assert CropRotate.from_dict({"orientation": "90"}).orientation == 0
+    assert CropRotate.from_dict({"angle": 90.0}).angle == 45.0
+    assert CropRotate.from_dict({"angle": "bad"}).angle == 0.0
+    assert CropRotate.from_dict({"rect": [0, 0, 1]}).rect == FULL_RECT
+    assert CropRotate.from_dict({"rect": [0, 0, 0.001, 1]}).rect == FULL_RECT
+    assert CropRotate.from_dict({"rect": "bad"}).rect == FULL_RECT
+    assert CropRotate.from_dict({"aspect": 3}).aspect == "Free"
+
+
+def test_aspect_defaults() -> None:
+    """Untouched images say Original; aspect-less sidecars say Free."""
+    assert CropRotate().aspect == "Original"
+    assert not CropRotate().aspect_swapped
+    old = CropRotate.from_dict({"rect": [0.1, 0.1, 0.5, 0.5]})
+    assert old.aspect == "Free"
+
+
+def test_rotated_size() -> None:
+    """Bounding boxes match hand-computed values."""
+    assert rotated_size(600, 400, 0.0) == (600, 400)
+    bw, bh = rotated_size(600, 400, 90.0)
+    assert bw == pytest.approx(400)
+    assert bh == pytest.approx(600)
+    bw, bh = rotated_size(100, 100, 45.0)
+    assert bw == pytest.approx(100 * math.sqrt(2))
+    assert bh == pytest.approx(100 * math.sqrt(2))
+
+
+def test_fits_full_rect() -> None:
+    """The full rect fits only when there is no fine angle."""
+    assert fits(600, 400, 0.0, FULL_RECT)
+    assert not fits(600, 400, 3.0, FULL_RECT)
+
+
+def test_largest_fit_no_angle() -> None:
+    """At zero angle the native aspect fills the whole frame."""
+    rect = largest_fit(600, 400, 0.0, 1.5)
+    assert rect == pytest.approx((0.0, 0.0, 1.0, 1.0))
+
+
+def test_largest_fit_square_on_landscape() -> None:
+    """A square crop on a 3:2 frame is height-limited and centered."""
+    rect = largest_fit(600, 400, 0.0, 1.0)
+    x, y, w, h = rect
+    assert w * 600 == pytest.approx(400)
+    assert h * 400 == pytest.approx(400)
+    assert x == pytest.approx((1 - w) / 2)
+    assert y == pytest.approx(0.0)
+
+
+def test_largest_fit_is_maximal() -> None:
+    """The fitted rect fits, a slightly larger one does not."""
+    for angle in (2.0, 7.5, -12.0, 30.0):
+        rect = largest_fit(600, 400, angle, 1.5)
+        assert fits(600, 400, angle, rect)
+        x, y, w, h = rect
+        grown = (
+            x - 0.01 * w,
+            y - 0.01 * h,
+            w * 1.02,
+            h * 1.02,
+        )
+        assert not fits(600, 400, angle, grown)
+
+
+def test_shrink_to_fit() -> None:
+    """An oversized rect shrinks about its center until it fits."""
+    rect = shrink_to_fit(600, 400, 5.0, FULL_RECT)
+    assert fits(600, 400, 5.0, rect)
+    x, y, w, h = rect
+    assert x + w / 2 == pytest.approx(0.5, abs=1e-6)
+    assert y + h / 2 == pytest.approx(0.5, abs=1e-6)
+    # An already-fitting rect is returned unchanged.
+    small = (0.4, 0.4, 0.2, 0.2)
+    assert shrink_to_fit(600, 400, 5.0, small) == small
+
+
+def test_constrain_drag_move() -> None:
+    """Moving toward the void stops at the rotated image edge."""
+    start = (0.1, 0.4, 0.2, 0.2)
+    assert fits(600, 400, 5.0, start)
+    result = constrain_drag(600, 400, 5.0, start, "move", dx=0.69, dy=0.0)
+    assert fits(600, 400, 5.0, result)
+    assert start[0] < result[0] < start[0] + 0.69
+    assert result[2:] == start[2:]  # a move never resizes
+    small = (0.45, 0.45, 0.1, 0.1)
+    moved = constrain_drag(600, 400, 5.0, small, "move", dx=0.01, dy=0.0)
+    assert moved == apply_drag(small, "move", 0.01, 0.0)
+
+
+def test_constrain_drag_move_slides_along_edges() -> None:
+    """A blocked axis does not stop movement along the other axis."""
+    start = (0.4, 0.4, 0.2, 0.2)
+    result = constrain_drag(600, 400, 5.0, start, "move", dx=0.05, dy=-0.8)
+    assert fits(600, 400, 5.0, result)
+    assert abs(result[0] - 0.45) < 0.08  # x stayed near the pointer
+    assert result[1] < 0.1  # y hugs the tilted top edge
+
+
+def test_constrain_drag_move_reaches_targets_exactly() -> None:
+    """Any legal target position is reached, no refusals."""
+    start = (0.4, 0.4, 0.2, 0.2)
+    result = constrain_drag(600, 400, 5.0, start, "move", dx=0.1, dy=-0.15)
+    assert result == pytest.approx((0.5, 0.25, 0.2, 0.2))
+
+
+def test_constrain_drag_conforms_stale_rect() -> None:
+    """A rect that no longer fits is conformed instead of freezing."""
+    stale = FULL_RECT  # the full rect never fits once there is an angle
+    assert not fits(600, 400, 5.0, stale)
+    grown = constrain_drag(600, 400, 5.0, stale, "e", dx=0.1, dy=0.0)
+    assert fits(600, 400, 5.0, grown)
+    moved = constrain_drag(600, 400, 5.0, stale, "move", dx=0.01, dy=0.0)
+    assert fits(600, 400, 5.0, moved)
+    assert moved[0] + moved[2] / 2 == pytest.approx(0.51, abs=0.02)
+
+
+def test_constrain_drag_resize_axes_are_independent() -> None:
+    """A blocked axis never holds a free-aspect corner's other axis."""
+    start = (0.3, 0.25, 0.2, 0.2)
+    diag = constrain_drag(600, 400, 5.0, start, "ne", dx=0.25, dy=-0.4)
+    pure_x = constrain_drag(600, 400, 5.0, start, "ne", dx=0.25, dy=0.0)
+    assert fits(600, 400, 5.0, diag)
+    assert diag[2] == pytest.approx(pure_x[2], abs=1e-9)
+    # Sweeping the blocked vertical back never changes the width.
+    widths = {
+        round(
+            constrain_drag(
+                600, 400, 5.0, start, "ne", dx=0.25, dy=-0.4 + i * 0.01
+            )[2],
+            9,
+        )
+        for i in range(41)
+    }
+    assert len(widths) == 1
+
+
+def test_constrain_drag_resize_escapes_micro_pinch() -> None:
+    """A border-hugging crop still scales at near-zero angles."""
+    angle = -0.02
+    hug = clamp_move(6000, 4000, angle, (0.01, 0.2, 0.3, 0.3), -1.0, 0.0)
+    assert fits(6000, 4000, angle, hug)
+    grown = constrain_drag(6000, 4000, angle, hug, "s", dx=0.0, dy=0.4)
+    assert fits(6000, 4000, angle, grown)
+    assert grown[3] > hug[3] + 0.35  # grew essentially the full drag
+    assert abs(grown[0] - hug[0]) < 0.001  # the nudge is invisible
+
+
+def test_clamp_move_full_reach() -> None:
+    """Corners of the tilted image are reachable, not just its middle."""
+    start = (0.45, 0.45, 0.1, 0.1)
+    corner = clamp_move(600, 400, 5.0, start, -0.6, -0.6)
+    assert fits(600, 400, 5.0, corner)
+    assert corner[1] < 0.05
+    again = constrain_drag(
+        600, 400, 5.0, start, "move", dx=corner[0] - 0.45, dy=corner[1] - 0.45
+    )
+    assert again == pytest.approx(corner)
+
+
+def test_constrain_drag_resize() -> None:
+    """A resize grows as far as the rotated image allows, no further."""
+    start = (0.1, 0.4, 0.2, 0.2)
+    result = constrain_drag(600, 400, 5.0, start, "e", dx=1.0, dy=0.0)
+    assert fits(600, 400, 5.0, result)
+    assert result[2] > start[2]  # it grew
+    assert result[3] == pytest.approx(start[3])
+    again = constrain_drag(600, 400, 5.0, start, "e", dx=1.0, dy=0.0)
+    assert again == result
+
+
+def test_rotate_rect_90_round_trips() -> None:
+    """90-degree carries compose back to the original rect."""
+    rect = (0.1, 0.2, 0.5, 0.3)
+    once = rotate_rect_90(rect, 90)
+    assert once == pytest.approx((0.5, 0.1, 0.3, 0.5))
+    back = rotate_rect_90(once, -90)
+    assert back == pytest.approx(rect)
+    twice = rotate_rect_90(rotate_rect_90(rect, 180), 180)
+    assert twice == pytest.approx(rect)
+    four = rect
+    for _ in range(4):
+        four = rotate_rect_90(four, 90)
+    assert four == pytest.approx(rect)
+
+
+def test_swap_rect_inverts_aspect() -> None:
+    """Swapping exchanges the crop's pixel width and height."""
+    out = swap_rect(600, 400, 0.0, FULL_RECT)
+    x, _y, w, h = out
+    pw, ph = w * 600, h * 400
+    assert pw / ph == pytest.approx(2 / 3)
+    assert ph == pytest.approx(400)
+    assert x == pytest.approx((1 - w) / 2)
+    small = swap_rect(600, 400, 0.0, (0.4, 0.375, 0.2, 0.25))
+    px, py, sw, sh = small
+    assert sw * 600 == pytest.approx(100)
+    assert sh * 400 == pytest.approx(120)
+    assert px + sw / 2 == pytest.approx(0.5)
+    assert py + sh / 2 == pytest.approx(0.5)
+    tilted = swap_rect(600, 400, 7.0, largest_fit(600, 400, 7.0, 1.5))
+    assert fits(600, 400, 7.0, tilted)
+    _tx, _ty, tw, th = tilted
+    bw, bh = rotated_size(600, 400, 7.0)
+    assert (tw * bw) / (th * bh) == pytest.approx(2 / 3)
+
+
+def test_hit_zone() -> None:
+    """Corners, edges, the inside and the outside are told apart."""
+    rect = (0.2, 0.2, 0.6, 0.6)
+    m = 0.02
+    assert hit_zone(rect, 0.2, 0.2, m, m) == "nw"
+    assert hit_zone(rect, 0.8, 0.2, m, m) == "ne"
+    assert hit_zone(rect, 0.2, 0.8, m, m) == "sw"
+    assert hit_zone(rect, 0.8, 0.8, m, m) == "se"
+    assert hit_zone(rect, 0.5, 0.2, m, m) == "n"
+    assert hit_zone(rect, 0.5, 0.8, m, m) == "s"
+    assert hit_zone(rect, 0.2, 0.5, m, m) == "w"
+    assert hit_zone(rect, 0.8, 0.5, m, m) == "e"
+    assert hit_zone(rect, 0.5, 0.5, m, m) == "move"
+    assert hit_zone(rect, 0.05, 0.05, m, m) is None
+
+
+def test_apply_drag_move_clamps() -> None:
+    """Moving the rect stops at the canvas border."""
+    rect = (0.2, 0.2, 0.6, 0.6)
+    moved = apply_drag(rect, "move", 0.5, -0.5)
+    assert moved == (0.4, 0.0, 0.6, 0.6)
+
+
+def test_apply_drag_edges_and_min_size() -> None:
+    """Edge drags resize one side and respect the minimum size."""
+    rect = (0.2, 0.2, 0.6, 0.6)
+    grown = apply_drag(rect, "e", 0.3, 0.0)
+    assert grown == pytest.approx((0.2, 0.2, 0.8, 0.6))
+    collapsed = apply_drag(rect, "e", -1.0, 0.0, min_w=0.05)
+    assert collapsed[2] == pytest.approx(0.05)
+
+
+def test_apply_drag_corner_with_ratio() -> None:
+    """A corner drag under a fixed aspect keeps that aspect."""
+    rect = (0.2, 0.2, 0.6, 0.6)
+    out = apply_drag(rect, "se", -0.1, -0.2, ratio=1.5)
+    x, y, w, h = out
+    assert w / h == pytest.approx(1.5)
+    assert (x, y) == (0.2, 0.2)
+    assert h == pytest.approx(0.4)
+
+
+def test_apply_drag_corner_ratio_single_axis() -> None:
+    """A purely horizontal corner drag still scales under a ratio."""
+    rect = (0.2, 0.2, 0.3, 0.2)
+    grown = apply_drag(rect, "se", 0.3, 0.0, ratio=1.5)
+    assert grown == pytest.approx((0.2, 0.2, 0.6, 0.4))
+    shrunk = apply_drag(rect, "se", -0.15, 0.0, ratio=1.5)
+    assert shrunk == pytest.approx((0.2, 0.2, 0.15, 0.1))
+    taller = apply_drag(rect, "se", 0.0, 0.2, ratio=1.5)
+    assert taller == pytest.approx((0.2, 0.2, 0.6, 0.4))
+
+
+def test_apply_drag_edge_ratio_survives_the_canvas() -> None:
+    """A wide east/west drag caps instead of breaking the ratio."""
+    rect = (0.3, 0.35, 0.2, 0.3)
+    out = apply_drag(rect, "e", 0.8, 0.0, ratio=2 / 3)
+    _x, y, w, h = out
+    assert w / h == pytest.approx(2 / 3)
+    assert w == pytest.approx(2 / 3)  # capped so h fits exactly
+    assert h == pytest.approx(1.0)
+    assert y >= 0.0
+    west = apply_drag(rect, "w", -0.8, 0.0, ratio=2 / 3)
+    assert west[2] / west[3] == pytest.approx(2 / 3)
+    tall = apply_drag((0.4, 0.1, 0.45, 0.3), "s", 0.9, 0.9, ratio=2 / 3)
+    assert tall[2] / tall[3] == pytest.approx(2 / 3)
+    assert tall[2] <= 1.0 and tall[3] <= 1.0
+
+
+def test_apply_drag_corner_ratio_survives_the_canvas() -> None:
+    """Corner drags keep the format when the follower hits the canvas."""
+    out = apply_drag((0.4, 0.4, 0.2, 0.3), "se", 0.6, 0.0, ratio=2 / 3)
+    x, y, w, h = out
+    assert w / h == pytest.approx(2 / 3)
+    assert x == pytest.approx(0.4)
+    assert x + w == pytest.approx(1.0)
+    assert y >= 0.0
+    assert y + h <= 1.0 + 1e-9
+
+
+def test_level_delta() -> None:
+    """The straighten delta levels lines to the nearest axis."""
+    assert level_delta(100.0, 0.0) == pytest.approx(0.0)
+    dy = math.tan(math.radians(3.0)) * 100.0
+    assert level_delta(100.0, dy) == pytest.approx(-3.0)
+    assert level_delta(100.0, -dy) == pytest.approx(3.0)
+    assert abs(level_delta(2.0, 100.0)) < 45.0
+    assert level_delta(0.0, 0.0) == 0.0
+
+
+def test_guide_lines() -> None:
+    """Composition guides produce the expected segments."""
+    assert guide_lines("None", 300, 200) == []
+    assert guide_lines("Bogus", 300, 200) == []
+    thirds = guide_lines("Thirds", 300, 200)
+    assert len(thirds) == 4
+    assert (100.0, 0.0, 100.0, 200.0) in thirds
+    assert (0.0, 100.0, 300.0, 100.0) not in thirds  # 2/3 is at ~133
+    assert len(guide_lines("Grid", 300, 200)) == 14
+    assert len(guide_lines("Center", 300, 200)) == 2
+    diagonals = guide_lines("Diagonals", 300, 200)
+    assert len(diagonals) == 4
+    assert (0.0, 0.0, 200.0, 200.0) in diagonals  # 45 degrees, min side
+    golden = guide_lines("Golden", 300, 200)
+    xs = sorted({line[0] for line in golden if line[0] == line[2]})
+    assert xs[1] / 300 == pytest.approx(0.618, abs=1e-3)
+    triangles = guide_lines("Triangles", 300, 200)
+    assert len(triangles) == 3
+    for x1, y1, x2, y2 in triangles[1:]:
+        dot = (x2 - x1) * 300 + (y2 - y1) * 200
+        assert dot == pytest.approx(0.0, abs=1e-9)
+
+
+def test_guide_lines_spiral() -> None:
+    """The golden spiral is continuous and stays inside the crop."""
+    lines = guide_lines("Spiral", 300, 200)
+    assert len(lines) > 100
+    eps = 1e-6
+    for (_, _, x2, y2), (nx1, ny1, _, _) in itertools.pairwise(lines):
+        assert abs(x2 - nx1) < eps
+        assert abs(y2 - ny1) < eps
+    for x1, y1, x2, y2 in lines:
+        for px, py in ((x1, y1), (x2, y2)):
+            assert -eps <= px <= 300 + eps
+            assert -eps <= py <= 200 + eps
+    assert lines[0][0] == pytest.approx(0.0)
+    assert lines[0][1] == pytest.approx(200.0)
+
+
+def test_guide_lines_spiral_portrait_and_mirror() -> None:
+    """Portrait crops get a transposed spiral; flips mirror it."""
+    eps = 1e-6
+    portrait = guide_lines("Spiral", 200, 300)
+    assert len(portrait) > 100
+    for x1, y1, x2, y2 in portrait:
+        for px, py in ((x1, y1), (x2, y2)):
+            assert -eps <= px <= 200 + eps
+            assert -eps <= py <= 300 + eps
+    assert portrait[0][0] == pytest.approx(200.0)
+    assert portrait[0][1] == pytest.approx(0.0)
+    mirrored = guide_lines("Spiral", 300, 200, flip_h=True)
+    assert mirrored[0][0] == pytest.approx(300.0)
+    assert mirrored[0][1] == pytest.approx(200.0)
+    flipped = guide_lines("Spiral", 300, 200, flip_v=True)
+    assert flipped[0][1] == pytest.approx(0.0)
+
+
+def test_sidecar_round_trip(tmp_path: Path) -> None:
+    """Geometry survives a save/load cycle next to the RAF."""
+    raf = tmp_path / "DSCF0001.RAF"
+    raf.write_bytes(b"raf")
+    value = CropRotate(orientation=90, angle=2.5, rect=(0.1, 0.1, 0.7, 0.6))
+    save_sidecar(raf, value)
+    assert sidecar_path(raf).name == "DSCF0001.RAF.grawji.json"
+    assert load_sidecar(raf) == value
+
+
+def test_sidecar_identity_removes_file(tmp_path: Path) -> None:
+    """Resetting the geometry deletes the sidecar again."""
+    raf = tmp_path / "DSCF0002.RAF"
+    raf.write_bytes(b"raf")
+    save_sidecar(raf, CropRotate(orientation=90))
+    assert sidecar_path(raf).exists()
+    save_sidecar(raf, CropRotate())
+    assert not sidecar_path(raf).exists()
+
+
+def test_sidecar_missing_or_corrupt(tmp_path: Path) -> None:
+    """Absent or unreadable sidecars fall back to the identity."""
+    raf = tmp_path / "DSCF0003.RAF"
+    assert load_sidecar(raf) == CropRotate()
+    sidecar_path(raf).write_text("not json", encoding="utf-8")
+    assert load_sidecar(raf) == CropRotate()
+    sidecar_path(raf).write_text(json.dumps({"crop": 5}), encoding="utf-8")
+    assert load_sidecar(raf) == CropRotate()

--- a/tests/test_export_geometry.py
+++ b/tests/test_export_geometry.py
@@ -1,0 +1,49 @@
+"""Batch export applies a RAF's geometry sidecar when one exists."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+from gi.repository import GdkPixbuf
+
+from grawji.crop import CropRotate, save_sidecar
+from grawji.views.export import sidecar_decode
+
+
+def _jpeg_bytes(width: int, height: int) -> bytes:
+    """Encode a plain filled image as JPEG bytes."""
+    pixbuf = GdkPixbuf.Pixbuf.new(
+        GdkPixbuf.Colorspace.RGB, False, 8, width, height
+    )
+    pixbuf.fill(0xFF8800FF)
+    ok, buffer = pixbuf.save_to_bufferv("jpeg", ["quality"], ["90"])
+    assert ok
+    return bytes(buffer)
+
+
+def test_sidecar_decode_without_sidecar(tmp_path: Path) -> None:
+    """No sidecar (or identity) means the camera bytes pass through."""
+    raf = tmp_path / "DSCF0001.RAF"
+    raf.write_bytes(b"raf")
+    assert sidecar_decode(str(raf)) is None
+    save_sidecar(raf, CropRotate())  # identity writes no file
+    assert sidecar_decode(str(raf)) is None
+
+
+def test_sidecar_decode_applies_geometry(tmp_path: Path) -> None:
+    """A stored crop/rotation is baked into the decoded pixels."""
+    raf = tmp_path / "DSCF0002.RAF"
+    raf.write_bytes(b"raf")
+    save_sidecar(
+        raf,
+        CropRotate(orientation=90, rect=(0.25, 0.25, 0.5, 0.5)),
+    )
+    decode = sidecar_decode(str(raf))
+    assert decode is not None
+    pixbuf = decode(_jpeg_bytes(600, 400))
+    assert (pixbuf.get_width(), pixbuf.get_height()) == (200, 300)

--- a/tests/test_export_geometry.py
+++ b/tests/test_export_geometry.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import gi
+import pytest
 
+gi = pytest.importorskip("gi")
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 


### PR DESCRIPTION
- crop editor in the preview: drag handles, aspect presets with landscape/portrait swap, fine angle, horizon-line straightening
- geometry stored in a JSON sidecar per RAF, applied on single and batch export
- filmstrip: altered-image badge, selection centered on startup

partly adds features requested in #60 