### PR TITLE
feat(crop, ui): store per-image EV in the sidecar

### DIFF
--- a/src/grawji/crop.py
+++ b/src/grawji/crop.py
@@ -12,20 +12,14 @@ orientation, then the fine angle, then the crop.
 
 from __future__ import annotations
 
-import json
-import logging
 import math
 from dataclasses import dataclass
-from pathlib import Path
 
 Rect = tuple[float, float, float, float]
 
 FULL_RECT: Rect = (0.0, 0.0, 1.0, 1.0)
 MAX_ANGLE = 45.0
 MIN_SIZE = 0.05
-SIDECAR_SUFFIX = ".grawji.json"
-
-_log = logging.getLogger("grawji")
 
 
 @dataclass(frozen=True)
@@ -622,36 +616,3 @@ def _spiral_lines(w: float, h: float) -> list[Line]:
         )
         for i in range(len(points) - 1)
     ]
-
-
-def sidecar_path(raf_path: Path | str) -> Path:
-    """The sidecar path for a RAF: the RAF name plus .grawji.json."""
-    raf = Path(raf_path)
-    return raf.with_name(raf.name + SIDECAR_SUFFIX)
-
-
-def load_sidecar(raf_path: Path | str) -> CropRotate:
-    """Load the RAF's geometry sidecar, or the identity when absent."""
-    path = sidecar_path(raf_path)
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return CropRotate()
-    if not isinstance(data, dict) or not isinstance(data.get("crop"), dict):
-        return CropRotate()
-    return CropRotate.from_dict(data["crop"])
-
-
-def save_sidecar(raf_path: Path | str, crop: CropRotate) -> None:
-    """Write the RAF's geometry sidecar, removing it for the identity."""
-    path = sidecar_path(raf_path)
-    try:
-        if crop.is_identity:
-            path.unlink(missing_ok=True)
-        else:
-            path.write_text(
-                json.dumps({"version": 1, "crop": crop.to_dict()}, indent=2),
-                encoding="utf-8",
-            )
-    except OSError as exc:
-        _log.warning("could not write sidecar %s: %s", path, exc)

--- a/src/grawji/sidecar.py
+++ b/src/grawji/sidecar.py
@@ -1,0 +1,86 @@
+"""Per-image sidecar storage.
+
+One sidecar per RAF holds everything grawji knows about that image
+beyond the recipe: the crop/rotate geometry and the per-image EV.
+The format contract: a top-level "version" plus one key per purpose.
+Readers ignore unknown keys, writers preserve them, and "version"
+only ever bumps on a break that ignoring keys cannot absorb.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from grawji.crop import CropRotate
+
+SIDECAR_SUFFIX = ".grawji.json"
+
+# The camera-honored EV range (below -2 the engine falls back to 0).
+_EV_MIN = -2.0
+_EV_MAX = 3.0
+
+_log = logging.getLogger("grawji")
+
+
+def sidecar_path(raf_path: Path | str) -> Path:
+    """The sidecar path for a RAF: the RAF name plus .grawji.json."""
+    raf = Path(raf_path)
+    return raf.with_name(raf.name + SIDECAR_SUFFIX)
+
+
+def _read(raf_path: Path | str) -> dict[str, object]:
+    """The sidecar's stored dict, or an empty one when absent/broken."""
+    try:
+        data = json.loads(sidecar_path(raf_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _update(raf_path: Path | str, key: str, value: object | None) -> None:
+    """Read-modify-write one sidecar key."""
+    path = sidecar_path(raf_path)
+    data = _read(raf_path)
+    data.pop("version", None)
+    if value is None:
+        data.pop(key, None)
+    else:
+        data[key] = value
+    try:
+        if data:
+            path.write_text(
+                json.dumps({"version": 1, **data}, indent=2),
+                encoding="utf-8",
+            )
+        else:
+            path.unlink(missing_ok=True)
+    except OSError as exc:
+        _log.warning("could not write sidecar %s: %s", path, exc)
+
+
+def load_crop(raf_path: Path | str) -> CropRotate:
+    """The RAF's stored geometry, or the identity when absent."""
+    value = _read(raf_path).get("crop")
+    if not isinstance(value, dict):
+        return CropRotate()
+    return CropRotate.from_dict(value)
+
+
+def save_crop(raf_path: Path | str, crop: CropRotate) -> None:
+    """Store the RAF's geometry, dropping the key for the identity."""
+    _update(raf_path, "crop", None if crop.is_identity else crop.to_dict())
+
+
+def load_exposure(raf_path: Path | str) -> float | None:
+    """The RAF's stored per-image EV, or None when never set."""
+    value = _read(raf_path).get("exposure")
+    if not isinstance(value, (int, float)):
+        return None
+    return max(_EV_MIN, min(_EV_MAX, float(value)))
+
+
+def save_exposure(raf_path: Path | str, exposure: float | None) -> None:
+    """Store the RAF's per-image EV (None removes it)."""
+    _update(raf_path, "exposure", exposure)

--- a/src/grawji/views/export.py
+++ b/src/grawji/views/export.py
@@ -6,6 +6,7 @@ import logging
 import tempfile
 import threading
 from collections.abc import Callable
+from dataclasses import replace
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -17,8 +18,8 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Gio, GLib, Gtk
 
-from grawji import crop
-from grawji.core import CameraSession, ForeignRafError
+from grawji import sidecar
+from grawji.core import CameraSession, ForeignRafError, recipe_from_profile
 from grawji.preview import CameraWorker
 from grawji.recipe import Recipe
 from grawji.settings import Settings
@@ -32,7 +33,7 @@ SetBusy = Callable[..., None]
 
 def sidecar_decode(raf_path: str) -> Callable[[bytes], Any] | None:
     """A decode callback applying the RAF's sidecar geometry, or None."""
-    geometry = crop.load_sidecar(raf_path)
+    geometry = sidecar.load_crop(raf_path)
     if geometry.is_identity:
         return None
     return lambda jpeg: bake_pixbuf(oriented_pixbuf(jpeg), geometry)
@@ -236,7 +237,10 @@ class BatchController:
         """Convert one RAF into out_path."""
         try:
             self._session.open(raf_file)
-            jpeg = self._session.render(recipe, full_resolution=True)
+            jpeg = self._session.render(
+                replace(recipe, exposure=self._image_exposure(raf_file)),
+                full_resolution=True,
+            )
         except ForeignRafError:
             if not skip_foreign:
                 raise
@@ -260,6 +264,16 @@ class BatchController:
             tally["failed"] += 1
         else:
             tally["exported"] += 1
+
+    def _image_exposure(self, raf_file: str) -> float:
+        """The EV to render raf_file with: stored, else as shot."""
+        stored = sidecar.load_exposure(raf_file)
+        if stored is not None:
+            return stored
+        profile = self._session.profile
+        if profile is None:
+            return 0.0
+        return recipe_from_profile(profile).exposure
 
     def _on_cancel(self) -> None:
         """Ask the running batch to stop after the current image."""

--- a/src/grawji/views/filmstrip.py
+++ b/src/grawji/views/filmstrip.py
@@ -18,9 +18,9 @@ gi.require_version("GExiv2", "0.10")
 
 from gi.repository import Gdk, GdkPixbuf, GExiv2, Gio, GLib, Gtk, Pango
 
-from grawji.crop import sidecar_path
 from grawji.raf import embedded_jpeg, embedded_jpeg_prefix
 from grawji.settings import cache_dir
+from grawji.sidecar import sidecar_path
 
 # How much of the embedded JPEG to read for the EXIF thumbnail (near the
 # start), so the multi-megabyte preview is not touched on the fast path.

--- a/src/grawji/views/recipe_manager.py
+++ b/src/grawji/views/recipe_manager.py
@@ -812,7 +812,9 @@ class RecipeLibraryController:
         recipe = self._library.get(name)
         if recipe is None:
             return
+        exposure = self._panel.get_recipe().exposure
         self._panel.set_active(recipe, name)
+        self._panel.set_exposure(exposure)
         self._on_render()
         self._on_status(f"Applied recipe “{name}”.{self._fit_note(recipe)}")
 
@@ -939,6 +941,7 @@ class RecipeLibraryController:
             activate: Re-render the preview after saving (used for imports,
                 where the saved recipe is new to the controls).
         """
+        recipe = replace(recipe, exposure=0.0)
         dialog = Adw.AlertDialog(
             heading="Save recipe", body="Name this recipe:"
         )

--- a/src/grawji/views/recipe_panel.py
+++ b/src/grawji/views/recipe_panel.py
@@ -339,6 +339,14 @@ class RecipePanel(Adw.PreferencesPage):
         self._update_grain_size_visibility()
         self._update_mono_visibility()
 
+    def set_exposure(self, value: float) -> None:
+        """Move only the exposure control, without emitting changed."""
+        self._suppress_signals = True
+        try:
+            self._exposure_row.set_value(value)
+        finally:
+            self._suppress_signals = False
+
     def set_active(self, recipe: Recipe, label: str) -> None:
         """Load a recipe and mark it active (for the recipe indicator)."""
         self._applied_recipe = recipe

--- a/src/grawji/views/window.py
+++ b/src/grawji/views/window.py
@@ -6,6 +6,7 @@ import contextlib
 import logging
 import threading
 from collections.abc import Callable
+from dataclasses import replace
 from functools import partial
 from importlib import resources
 from pathlib import Path
@@ -18,7 +19,7 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Adw, Gdk, Gio, GLib, Gtk
 
-from grawji import camera_info, crop, raf
+from grawji import camera_info, raf, sidecar
 from grawji.capabilities import (
     Capabilities,
     capabilities_for,
@@ -132,6 +133,8 @@ class MainWindow(Adw.ApplicationWindow):
         self.connect("close-request", self._on_close_request)
 
         self._raf_path: Path | None = None
+        self._stored_ev: float | None = None
+        self._image_ev: float | None = None
         self._current_folder: str | None = None
         self._notified_models: set[str] = set()
         self._exif_rows: list[Any] = []
@@ -405,7 +408,9 @@ class MainWindow(Adw.ApplicationWindow):
         self._load_pending_id = 0
         if generation != self._generation:
             return GLib.SOURCE_REMOVE
-        self.preview_view.set_crop(crop.load_sidecar(raf_path))
+        self.preview_view.set_crop(sidecar.load_crop(raf_path))
+        self._stored_ev = sidecar.load_exposure(raf_path)
+        self._image_ev = None
         # The camera open runs on its own worker. The embedded-preview read
         # and decode run on a short-lived thread. Neither blocks the UI, so
         # the filmstrip animation stays smooth and the image appears as soon
@@ -480,18 +485,31 @@ class MainWindow(Adw.ApplicationWindow):
             else self._recipe_library.get(selection)
         )
         from_image = selection == FROM_IMAGE or saved is None
+        shot_recipe = (
+            recipe_from_profile(profile) if profile is not None else Recipe()
+        )
+        # EV is per image: the stored override wins, else the shot EV.
+        ev = (
+            self._stored_ev
+            if self._stored_ev is not None
+            else shot_recipe.exposure
+        )
         if profile is not None and from_image:
-            self.recipe_panel.set_active(
-                recipe_from_profile(profile), FROM_IMAGE_LABEL
-            )
+            self.recipe_panel.set_active(shot_recipe, FROM_IMAGE_LABEL)
             # The loaded recipe is the image's own, so the embedded JPEG
             # already shown is exactly what a render would produce - skip the
-            # slow conversion round-trip until the user actually edits.
-            if self.preview_view.has_embedded_jpeg:
+            # slow conversion round-trip until the user actually edits. A
+            # stored EV override changes the result, so it must render.
+            if (
+                self.preview_view.has_embedded_jpeg
+                and ev == shot_recipe.exposure
+            ):
                 self._set_busy(busy=False, status="Ready.")
                 render_working = False
         elif saved is not None:
             self.recipe_panel.set_active(saved, selection)
+        self.recipe_panel.set_exposure(ev)
+        self._image_ev = ev
         if render_working:
             self._render_preview()
         # Comparing carries across images: refresh the baseline for this one.
@@ -574,7 +592,10 @@ class MainWindow(Adw.ApplicationWindow):
         baseline = self._recipe_library.baseline_recipe()
         if baseline is None:
             return
-        # Rendering the baseline is a camera round-trip; show progress so
+        baseline = replace(
+            baseline, exposure=self.recipe_panel.get_recipe().exposure
+        )
+        # Rendering the baseline is a camera round-trip. Show progress so
         # the wait before the split appears is not a dead moment.
         self._set_busy(busy=True, status="Preparing comparison…")
         self._worker.submit(
@@ -598,8 +619,20 @@ class MainWindow(Adw.ApplicationWindow):
 
     def _on_recipe_changed(self, _panel: Any) -> None:
         """Re-render (debounced) after a recipe edit."""
-        if self._session.is_open:
-            self._schedule_render()
+        if not self._session.is_open:
+            return
+        self._persist_exposure()
+        self._schedule_render()
+
+    def _persist_exposure(self) -> None:
+        """Store the image's EV in its sidecar when it changed."""
+        if self._raf_path is None:
+            return
+        ev = self.recipe_panel.get_recipe().exposure
+        if self._image_ev is not None and ev == self._image_ev:
+            return
+        self._image_ev = ev
+        sidecar.save_exposure(self._raf_path, ev)
 
     def _on_apply_recipe(self, _panel: Any, name: str) -> None:
         """Apply and remember the recipe chosen in the panel's picker."""
@@ -618,11 +651,15 @@ class MainWindow(Adw.ApplicationWindow):
         self.recipe_panel.set_active(
             recipe_from_profile(profile), FROM_IMAGE_LABEL
         )
+        if self._image_ev is not None:
+            self.recipe_panel.set_exposure(self._image_ev)
         self._render_if_open()
 
     def _reset_recipe(self) -> None:
-        """Reset all controls to the default recipe."""
+        """Reset all controls to the default recipe, keeping the EV."""
+        exposure = self.recipe_panel.get_recipe().exposure
         self.recipe_panel.set_active(Recipe(), "Default")
+        self.recipe_panel.set_exposure(exposure)
         self._render_if_open()
 
     def _render_if_open(self) -> None:
@@ -781,9 +818,9 @@ class MainWindow(Adw.ApplicationWindow):
         """Persist a committed crop/rotation to the RAF's sidecar."""
         if self._raf_path is None:
             return
-        crop.save_sidecar(self._raf_path, self.preview_view.crop_rotate)
+        sidecar.save_crop(self._raf_path, self.preview_view.crop_rotate)
         self._filmstrip.set_altered(
-            str(self._raf_path), crop.sidecar_path(self._raf_path).exists()
+            str(self._raf_path), sidecar.sidecar_path(self._raf_path).exists()
         )
 
     def _populate_exif_rows(self, rows: list[tuple[str, str]]) -> None:

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import itertools
-import json
 import math
-from pathlib import Path
 
 import pytest
 
@@ -20,12 +18,9 @@ from grawji.crop import (
     hit_zone,
     largest_fit,
     level_delta,
-    load_sidecar,
     rotate_rect_90,
     rotated_size,
-    save_sidecar,
     shrink_to_fit,
-    sidecar_path,
     swap_rect,
 )
 
@@ -407,33 +402,3 @@ def test_guide_lines_spiral_portrait_and_mirror() -> None:
     assert mirrored[0][1] == pytest.approx(200.0)
     flipped = guide_lines("Spiral", 300, 200, flip_v=True)
     assert flipped[0][1] == pytest.approx(0.0)
-
-
-def test_sidecar_round_trip(tmp_path: Path) -> None:
-    """Geometry survives a save/load cycle next to the RAF."""
-    raf = tmp_path / "DSCF0001.RAF"
-    raf.write_bytes(b"raf")
-    value = CropRotate(orientation=90, angle=2.5, rect=(0.1, 0.1, 0.7, 0.6))
-    save_sidecar(raf, value)
-    assert sidecar_path(raf).name == "DSCF0001.RAF.grawji.json"
-    assert load_sidecar(raf) == value
-
-
-def test_sidecar_identity_removes_file(tmp_path: Path) -> None:
-    """Resetting the geometry deletes the sidecar again."""
-    raf = tmp_path / "DSCF0002.RAF"
-    raf.write_bytes(b"raf")
-    save_sidecar(raf, CropRotate(orientation=90))
-    assert sidecar_path(raf).exists()
-    save_sidecar(raf, CropRotate())
-    assert not sidecar_path(raf).exists()
-
-
-def test_sidecar_missing_or_corrupt(tmp_path: Path) -> None:
-    """Absent or unreadable sidecars fall back to the identity."""
-    raf = tmp_path / "DSCF0003.RAF"
-    assert load_sidecar(raf) == CropRotate()
-    sidecar_path(raf).write_text("not json", encoding="utf-8")
-    assert load_sidecar(raf) == CropRotate()
-    sidecar_path(raf).write_text(json.dumps({"crop": 5}), encoding="utf-8")
-    assert load_sidecar(raf) == CropRotate()

--- a/tests/test_export_geometry.py
+++ b/tests/test_export_geometry.py
@@ -12,7 +12,8 @@ gi.require_version("Adw", "1")
 
 from gi.repository import GdkPixbuf
 
-from grawji.crop import CropRotate, save_sidecar
+from grawji.crop import CropRotate
+from grawji.sidecar import save_crop
 from grawji.views.export import sidecar_decode
 
 
@@ -32,7 +33,7 @@ def test_sidecar_decode_without_sidecar(tmp_path: Path) -> None:
     raf = tmp_path / "DSCF0001.RAF"
     raf.write_bytes(b"raf")
     assert sidecar_decode(str(raf)) is None
-    save_sidecar(raf, CropRotate())  # identity writes no file
+    save_crop(raf, CropRotate())  # identity writes no file
     assert sidecar_decode(str(raf)) is None
 
 
@@ -40,7 +41,7 @@ def test_sidecar_decode_applies_geometry(tmp_path: Path) -> None:
     """A stored crop/rotation is baked into the decoded pixels."""
     raf = tmp_path / "DSCF0002.RAF"
     raf.write_bytes(b"raf")
-    save_sidecar(
+    save_crop(
         raf,
         CropRotate(orientation=90, rect=(0.25, 0.25, 0.5, 0.5)),
     )

--- a/tests/test_sidecar.py
+++ b/tests/test_sidecar.py
@@ -1,0 +1,101 @@
+"""Tests for the per-image sidecar storage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from grawji.crop import CropRotate
+from grawji.sidecar import (
+    load_crop,
+    load_exposure,
+    save_crop,
+    save_exposure,
+    sidecar_path,
+)
+
+
+def test_sidecar_round_trip(tmp_path: Path) -> None:
+    """Geometry survives a save/load cycle next to the RAF."""
+    raf = tmp_path / "DSCF0001.RAF"
+    raf.write_bytes(b"raf")
+    value = CropRotate(orientation=90, angle=2.5, rect=(0.1, 0.1, 0.7, 0.6))
+    save_crop(raf, value)
+    assert sidecar_path(raf).name == "DSCF0001.RAF.grawji.json"
+    assert load_crop(raf) == value
+
+
+def test_sidecar_identity_removes_file(tmp_path: Path) -> None:
+    """Resetting the geometry deletes the sidecar again."""
+    raf = tmp_path / "DSCF0002.RAF"
+    raf.write_bytes(b"raf")
+    save_crop(raf, CropRotate(orientation=90))
+    assert sidecar_path(raf).exists()
+    save_crop(raf, CropRotate())
+    assert not sidecar_path(raf).exists()
+
+
+def test_sidecar_exposure(tmp_path: Path) -> None:
+    """Per-image EV lives beside the crop; each survives the other."""
+    raf = tmp_path / "DSCF0004.RAF"
+    raf.write_bytes(b"raf")
+    assert load_exposure(raf) is None
+    save_exposure(raf, 1 + 2 / 3)
+    save_crop(raf, CropRotate(orientation=90))
+    assert load_exposure(raf) == pytest.approx(1 + 2 / 3)
+    assert load_crop(raf).orientation == 90
+    # Resetting the crop keeps the EV, so the file stays.
+    save_crop(raf, CropRotate())
+    assert sidecar_path(raf).exists()
+    assert load_exposure(raf) == pytest.approx(1 + 2 / 3)
+    assert load_crop(raf) == CropRotate()
+    # Removing the EV as well deletes the whole sidecar.
+    save_exposure(raf, None)
+    assert not sidecar_path(raf).exists()
+
+
+def test_sidecar_exposure_sanitized(tmp_path: Path) -> None:
+    """Stored EV is clamped to the camera-honored range or ignored."""
+    raf = tmp_path / "DSCF0005.RAF"
+    raf.write_bytes(b"raf")
+    sidecar_path(raf).write_text(
+        json.dumps({"version": 1, "exposure": 9.0}), encoding="utf-8"
+    )
+    assert load_exposure(raf) == 3.0
+    sidecar_path(raf).write_text(
+        json.dumps({"version": 1, "exposure": "bad"}), encoding="utf-8"
+    )
+    assert load_exposure(raf) is None
+
+
+def test_sidecar_preserves_unknown_keys(tmp_path: Path) -> None:
+    """Keys from future versions survive this version's writes."""
+    raf = tmp_path / "DSCF0006.RAF"
+    raf.write_bytes(b"raf")
+    sidecar_path(raf).write_text(
+        json.dumps({"version": 1, "rating": 5}), encoding="utf-8"
+    )
+    save_exposure(raf, 0.5)
+    save_crop(raf, CropRotate(orientation=180))
+    data = json.loads(sidecar_path(raf).read_text(encoding="utf-8"))
+    assert data["rating"] == 5
+    assert data["exposure"] == 0.5
+    assert data["version"] == 1
+    # An identity crop and no EV still keep the file: rating remains.
+    save_crop(raf, CropRotate())
+    save_exposure(raf, None)
+    assert sidecar_path(raf).exists()
+    data = json.loads(sidecar_path(raf).read_text(encoding="utf-8"))
+    assert data == {"version": 1, "rating": 5}
+
+
+def test_sidecar_missing_or_corrupt(tmp_path: Path) -> None:
+    """Absent or unreadable sidecars fall back to the identity."""
+    raf = tmp_path / "DSCF0003.RAF"
+    assert load_crop(raf) == CropRotate()
+    sidecar_path(raf).write_text("not json", encoding="utf-8")
+    assert load_crop(raf) == CropRotate()
+    sidecar_path(raf).write_text(json.dumps({"crop": 5}), encoding="utf-8")
+    assert load_crop(raf) == CropRotate()


### PR DESCRIPTION
- exposure is a per-shot correction, not part of a recipe: applying, resetting or saving recipes no longer touches or carries EV
- batch export renders each image with its own EV