### PR TITLE
feat(recipe, ui): keep modified recipes across images, split EV out

### DIFF
--- a/src/grawji/imaging/imagemeta.py
+++ b/src/grawji/imaging/imagemeta.py
@@ -124,7 +124,7 @@ def copy_exif(
     try:
         metadata = GExiv2.Metadata()
         metadata.open_buf(source_jpeg)
-        metadata.set_orientation(GExiv2.Orientation.NORMAL)
+        metadata.try_set_orientation(GExiv2.Orientation.NORMAL)
         _stamp(metadata, artist=artist, rights=rights, comment=comment)
         metadata.save_file(dest_path)
     except GLib.Error:

--- a/src/grawji/imaging/thumbnails.py
+++ b/src/grawji/imaging/thumbnails.py
@@ -291,7 +291,7 @@ def _exif_thumbnail(jpeg: bytes) -> tuple[bytes, int, ThumbMeta] | None:
     if not thumb:
         return None
     try:
-        orientation = int(meta.get_orientation())
+        orientation = int(meta.try_get_orientation())
     except (GLib.Error, ValueError):
         orientation = 1
     return bytes(thumb), orientation, _tags_of(meta)

--- a/src/grawji/ui/grawji.cmb
+++ b/src/grawji/ui/grawji.cmb
@@ -3,7 +3,7 @@
 <!-- Created with Cambalache 1.0.3 -->
 <cambalache-project version="1.0.0" target_tk="gtk-4.0" depends="libadwaita-1">
   <ui filename="preview_view.ui" sha256="bd12e0d77205d9a804c8b4efd3d6c01df96ca2bcc9de95b312ac7363ec58681c"/>
-  <ui filename="recipe_panel.ui" sha256="30e5e8c4659cf6b54c0dbce9c2d2eecc69150d6777b3cb03325b5363bc8c2337"/>
+  <ui filename="recipe_panel.ui" sha256="454ac35707639c911d34f5fc5b513849faaf7e1724cfcc33b593532465c89bdf"/>
   <ui filename="grawji.ui" sha256="f96e9c7592c4a4b7a08d27ff80b8c7ed7725f6da6799fafb6057ed96345487a4"/>
   <ui filename="batch_export.ui" sha256="684f45e4fd429b17511ec6c3dad138195d605a5f3bf6e70491bceec54337273a"/>
   <ui filename="preferences.ui" sha256="41f5c1769d88c0fb81b8f2bb02ce16d0fd67efd4f05eab65f49681113d926f85"/>

--- a/src/grawji/ui/recipe_panel.ui
+++ b/src/grawji/ui/recipe_panel.ui
@@ -63,5 +63,12 @@
       <object class="AdwPreferencesGroup" id="recipe_group">
       </object>
     </child>
+    <child>
+      <object class="AdwPreferencesGroup" id="exposure_group">
+        <property name="title">Exposure</property>
+        <property name="description">Per image, not part of the recipe</property>
+        <property name="margin-top">10</property>
+      </object>
+    </child>
   </template>
 </interface>

--- a/src/grawji/views/recipe_manager.py
+++ b/src/grawji/views/recipe_manager.py
@@ -570,8 +570,13 @@ class RecipeLibraryController:
             self._manager.show_toast(message)
 
     def save_current(self) -> None:
-        """Ask for a name and save the panel's controls as a recipe."""
-        self._prompt_save(self._panel.get_recipe())
+        """Ask for a name and save the panel's controls as a recipe.
+
+        A modified saved recipe prefills its own name.
+        """
+        label = self._panel.active_label
+        default = label if self._library.get(label) is not None else ""
+        self._prompt_save(self._panel.get_recipe(), default)
 
     def apply(self, name: str) -> None:
         """Apply a saved recipe to the controls and re-render."""
@@ -742,7 +747,8 @@ class RecipeLibraryController:
             model = self._get_model()
             if model:
                 recipe = replace(recipe, origin_body=model)
-        self._library.add(name, recipe)
+        # Overwriting keeps the recipe in its folder.
+        self._library.add(name, recipe, folder=self._library.folder_of(name))
         self._refresh()
         self._panel.set_active(recipe, name)
         if activate:

--- a/src/grawji/views/recipe_panel.py
+++ b/src/grawji/views/recipe_panel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import replace
 from importlib import resources
 from typing import Any, ClassVar
 
@@ -86,6 +87,7 @@ class RecipePanel(Adw.PreferencesPage):
     recipe_row = Gtk.Template.Child()
     recipe_button = Gtk.Template.Child()
     recipe_group = Gtk.Template.Child()
+    exposure_group = Gtk.Template.Child()
 
     def __init__(self, **kwargs: object) -> None:
         """Build the rows (in Fuji IQ-menu order) and wire their signals."""
@@ -108,6 +110,7 @@ class RecipePanel(Adw.PreferencesPage):
 
         self._build_rows()
         self._connect_signals()
+        self._applied_recipe = self.get_recipe()
         self._update_status()
 
     def _build_rows(self) -> None:
@@ -166,6 +169,7 @@ class RecipePanel(Adw.PreferencesPage):
         wb_box.append(self._wb_grid)
         wb_box.append(self._wb_shift_label)
         grid_row = Adw.ActionRow(title="WB shift")
+        self._wb_shift_row = grid_row
         grid_row.add_suffix(wb_box)
         self._update_wb_shift_label()
 
@@ -219,7 +223,6 @@ class RecipePanel(Adw.PreferencesPage):
             self._temp_row,
             grid_row,
             self.dr_row,
-            self._exposure_row,
             self._highlights_row,
             self._shadows_row,
             self._color_row,
@@ -229,6 +232,31 @@ class RecipePanel(Adw.PreferencesPage):
             self.color_space_row,
         ):
             self.recipe_group.add(row)
+        # EV is per image, not part of the recipe: it lives in its own
+        # group, is not saved into recipes and never counts as modified.
+        self.exposure_group.add(self._exposure_row)
+        self._field_rows: dict[str, Gtk.Widget] = {
+            "film_simulation": self.film_row,
+            "grain": self.grain_row,
+            "grain_size": self.grain_size_row,
+            "color_chrome": self.chrome_row,
+            "color_chrome_blue": self.chrome_blue_row,
+            "smooth_skin": self.smooth_skin_row,
+            "white_balance": self.wb_row,
+            "color_temp": self._temp_row,
+            # Covers wb_shift_b too (one row, checked as a pair).
+            "wb_shift_r": self._wb_shift_row,
+            "dynamic_range": self.dr_row,
+            "highlights": self._highlights_row,
+            "shadows": self._shadows_row,
+            "color": self._color_row,
+            "sharpness": self._sharpness_row,
+            "noise_reduction": self._nr_row,
+            "clarity": self._clarity_row,
+            "mono_warm_cool": self._mono_wc_row,
+            "mono_magenta_green": self._mono_grid_row,
+            "color_space": self.color_space_row,
+        }
         self._update_temp_visibility()
         self._update_grain_size_visibility()
         self._update_mono_visibility()
@@ -335,6 +363,7 @@ class RecipePanel(Adw.PreferencesPage):
             )
         finally:
             self._suppress_signals = False
+        self._update_status()
         self._update_temp_visibility()
         self._update_grain_size_visibility()
         self._update_mono_visibility()
@@ -348,10 +377,10 @@ class RecipePanel(Adw.PreferencesPage):
             self._suppress_signals = False
 
     def set_active(self, recipe: Recipe, label: str) -> None:
-        """Load a recipe and mark it active (for the recipe indicator)."""
-        self._applied_recipe = recipe
+        """Load a recipe and mark it active."""
         self._active_label = label
         self.set_recipe(recipe)
+        self._applied_recipe = self.get_recipe()
         self._update_status()
         self.sync_combo(label)
 
@@ -361,16 +390,21 @@ class RecipePanel(Adw.PreferencesPage):
         return self._active_label
 
     @property
+    def is_modified(self) -> bool:
+        """Whether the controls diverge from the applied recipe."""
+        current = replace(self.get_recipe(), exposure=0.0)
+        return current != replace(self._applied_recipe, exposure=0.0)
+
+    @property
     def provenance(self) -> str:
         """A short provenance line for exports.
 
         An unmodified "From image" state is the camera's own recipe,
         so there is nothing of grawji's to record.
         """
-        modified = self.get_recipe() != self._applied_recipe
-        if self._active_label == FROM_IMAGE_LABEL and not modified:
+        if self._active_label == FROM_IMAGE_LABEL and not self.is_modified:
             return ""
-        suffix = " (modified)" if modified else ""
+        suffix = " (modified)" if self.is_modified else ""
         return f"grawji recipe: {self._active_label}{suffix}"
 
     def apply_capabilities(self, caps: Capabilities) -> None:
@@ -595,11 +629,26 @@ class RecipePanel(Adw.PreferencesPage):
         supported = self._caps is None or self._caps.has_grain_size
         self.grain_size_row.set_visible(supported and grain != "Off")
 
+    def _update_modified_marks(self) -> None:
+        """Tint each row that diverges from the applied recipe."""
+        current = self.get_recipe()
+        for field, row in self._field_rows.items():
+            changed = getattr(current, field) != getattr(
+                self._applied_recipe, field
+            )
+            if field == "wb_shift_r" and not changed:
+                changed = current.wb_shift_b != self._applied_recipe.wb_shift_b
+            if changed:
+                row.add_css_class("recipe-modified")
+            else:
+                row.remove_css_class("recipe-modified")
+
     def _update_status(self) -> None:
         """Show the active recipe/source and whether it has been modified."""
-        if self.get_recipe() == self._applied_recipe:
-            self.recipe_group.set_description(self._active_label)
-        else:
+        self._update_modified_marks()
+        if self.is_modified:
             self.recipe_group.set_description(
                 f"{self._active_label} (modified)"
             )
+        else:
+            self.recipe_group.set_description(self._active_label)

--- a/src/grawji/views/window.py
+++ b/src/grawji/views/window.py
@@ -72,6 +72,8 @@ _LOAD_DELAY_MS = 50
 _DEFAULT_SIDEBAR_WIDTH = 240
 # Pane positions at or below this count as collapsed.
 _SIDEBAR_COLLAPSED_MAX = 10
+# EVs are thirds of a stop, anything closer than this is the same EV.
+_EV_EPSILON = 1e-6
 
 # App-wide CSS: preview canvas backgrounds, thumbnails, the folder tree.
 _CANVAS_CSS = """
@@ -100,6 +102,10 @@ button.thumb.thumb-marked {
 /* Filmstrip nav buttons: round only the edge facing the window border. */
 .filmstrip-nav-start { border-radius: 0 0 0 8px; }
 .filmstrip-nav-end { border-radius: 0 0 8px 0; }
+/* Subtle tint on recipe rows that differ from the applied recipe. */
+row.recipe-modified {
+    background-color: alpha(@accent_bg_color, 0.08);
+}
 /* Zero tick under the straighten slider. */
 .angle-zero-mark {
     background-color: alpha(currentColor, 0.55);
@@ -148,12 +154,13 @@ class MainWindow(Adw.ApplicationWindow):
         self._raf_path: Path | None = None
         self._stored_ev: float | None = None
         self._image_ev: float | None = None
+        self._shot_ev: float | None = None
         self._current_folder: str | None = None
         self._notified_models: set[str] = set()
         self._exif_rows: list[Any] = []
-        self._render_pending_id = 0
-        self._load_pending_id = 0
+        self._render_pending_id = self._load_pending_id = 0
         self._error_showing = False
+        self._close_confirmed = self._camera_seen = False
         # Bumped on every image selection. Async open/preview callbacks carry
         # the value they were issued under and ignore themselves if a newer
         # selection has superseded them (fast filmstrip scrubbing).
@@ -474,6 +481,7 @@ class MainWindow(Adw.ApplicationWindow):
         self.preview_view.set_crop(sidecar.load_crop(raf_path))
         self._stored_ev = sidecar.load_exposure(raf_path)
         self._image_ev = None
+        self._shot_ev = None
         # The camera open runs on its own worker. The embedded-preview read
         # and decode run on a short-lived thread. Neither blocks the UI, so
         # the filmstrip animation stays smooth and the image appears as soon
@@ -532,6 +540,11 @@ class MainWindow(Adw.ApplicationWindow):
         """Show the first preview, applying the sticky recipe selection."""
         if generation != self._generation:
             return  # a newer selection has superseded this open
+        carry = (
+            self.recipe_panel.get_recipe()
+            if self.recipe_panel.is_modified
+            else None
+        )
         profile = self._session.profile
         if profile is not None:
             # The RAF is provably from the connected body (a foreign one
@@ -546,6 +559,24 @@ class MainWindow(Adw.ApplicationWindow):
             )
             self._notify_unverified(model)
         render_working = True
+        shot_recipe = (
+            recipe_from_profile(profile) if profile is not None else Recipe()
+        )
+        # EV is per image: the stored override wins, else the shot EV.
+        self._shot_ev = shot_recipe.exposure
+        ev = (
+            self._stored_ev
+            if self._stored_ev is not None
+            else shot_recipe.exposure
+        )
+        if carry is not None:
+            self.recipe_panel.set_recipe(carry)
+            self.recipe_panel.set_exposure(ev)
+            self._image_ev = ev
+            self._render_preview()
+            if self.preview_view.comparing:
+                self._render_baseline(self._generation)
+            return
         selection = self._settings.open_recipe
         saved = (
             None
@@ -553,15 +584,6 @@ class MainWindow(Adw.ApplicationWindow):
             else self._recipe_library.get(selection)
         )
         from_image = selection == FROM_IMAGE or saved is None
-        shot_recipe = (
-            recipe_from_profile(profile) if profile is not None else Recipe()
-        )
-        # EV is per image: the stored override wins, else the shot EV.
-        ev = (
-            self._stored_ev
-            if self._stored_ev is not None
-            else shot_recipe.exposure
-        )
         if profile is not None and from_image:
             self.recipe_panel.set_active(shot_recipe, FROM_IMAGE_LABEL)
             # The loaded recipe is the image's own, so the embedded JPEG
@@ -700,7 +722,10 @@ class MainWindow(Adw.ApplicationWindow):
         if self._image_ev is not None and ev == self._image_ev:
             return
         self._image_ev = ev
-        sidecar.save_exposure(self._raf_path, ev)
+        back_to_shot = (
+            self._shot_ev is not None and abs(ev - self._shot_ev) < _EV_EPSILON
+        )
+        sidecar.save_exposure(self._raf_path, None if back_to_shot else ev)
         self._filmstrip.refresh_badges(str(self._raf_path))
 
     def _on_try_recipes(self) -> None:
@@ -767,6 +792,10 @@ class MainWindow(Adw.ApplicationWindow):
         dialog.present(self)
 
     def _on_apply_recipe(self, _panel: Any, name: str) -> None:
+        """Apply the picker's choice, guarding unsaved recipe edits."""
+        self._confirm_recipe_discard(partial(self._apply_choice, name))
+
+    def _apply_choice(self, name: str) -> None:
         """Apply and remember the recipe chosen in the panel's picker."""
         self._settings.open_recipe = name
         self._save_settings()
@@ -774,6 +803,35 @@ class MainWindow(Adw.ApplicationWindow):
             self._apply_from_image()
         else:
             self._library.apply(name)
+
+    def _confirm_recipe_discard(self, proceed: Callable[[], None]) -> None:
+        """Run proceed, first asking about unsaved recipe edits."""
+        if not self.recipe_panel.is_modified:
+            proceed()
+            return
+        dialog = Adw.AlertDialog(
+            heading="Unsaved recipe changes",
+            body=(
+                f"The controls changed since "
+                f"“{self.recipe_panel.active_label}” was applied."
+            ),
+        )
+        dialog.add_response("cancel", "Cancel")
+        dialog.add_response("discard", "Discard")
+        dialog.add_response("save", "Save…")
+        dialog.set_response_appearance(
+            "discard", Adw.ResponseAppearance.DESTRUCTIVE
+        )
+        dialog.set_default_response("save")
+
+        def on_response(_dialog: Any, response: str) -> None:
+            if response == "discard":
+                proceed()
+            elif response == "save":
+                self._library.save_current()
+
+        dialog.connect("response", on_response)
+        dialog.present(self)
 
     def _apply_from_image(self) -> None:
         """Load the open image's own in-camera recipe into the controls."""
@@ -1144,9 +1202,17 @@ class MainWindow(Adw.ApplicationWindow):
     def _refresh_camera_status(self) -> bool:
         """Update the header subtitle with the connected camera, if any."""
         model = camera_info.detect_camera()
+        appeared = bool(model) and not self._camera_seen
+        self._camera_seen = bool(model)
         self.window_title.set_subtitle(
             f"{model} connected" if model else "No camera"
         )
+        if (
+            appeared
+            and self._raf_path is not None
+            and not self._session.is_open
+        ):
+            self._on_raf_selected(str(self._raf_path))
         return GLib.SOURCE_CONTINUE
 
     def _on_preferences(self) -> None:
@@ -1203,9 +1269,17 @@ class MainWindow(Adw.ApplicationWindow):
 
     def _on_close_request(self, _window: Any) -> bool:
         """Persist window size, stop the worker, then allow closing."""
+        if self.recipe_panel.is_modified and not self._close_confirmed:
+            self._confirm_recipe_discard(self._close_discarded)
+            return True
         self._settings.window_width = self.get_width()
         self._settings.window_height = self.get_height()
         self._settings.sidebar_width = self.main_paned.get_position()
         self._save_settings()
         self._worker.stop()
         return False
+
+    def _close_discarded(self) -> None:
+        """Close for real after the user discarded the recipe edits."""
+        self._close_confirmed = True
+        self.close()

--- a/tests/test_views_smoke.py
+++ b/tests/test_views_smoke.py
@@ -77,6 +77,82 @@ def test_recipe_panel_provenance_line() -> None:
     assert panel.provenance == "grawji recipe: Summer (modified)"
 
 
+def test_ev_never_counts_as_modified() -> None:
+    """The per-image EV is not part of the recipe."""
+    from grawji.recipe import Recipe
+    from grawji.views.recipe_panel import RecipePanel
+
+    panel = RecipePanel()
+    pump()
+    panel.set_active(Recipe(film_simulation="Velvia"), "Summer")
+    panel.set_active(panel.get_recipe(), "Summer")
+    panel.set_exposure(1.0)
+    assert not panel.is_modified
+    assert panel.provenance == "grawji recipe: Summer"
+
+
+def test_modified_rows_get_the_tint() -> None:
+    """Only rows that diverge from the applied recipe are tinted."""
+    from dataclasses import replace
+
+    from grawji.recipe import Recipe
+    from grawji.views.recipe_panel import RecipePanel
+
+    panel = RecipePanel()
+    pump()
+    panel.set_active(Recipe(film_simulation="Velvia"), "Summer")
+    assert not panel.film_row.has_css_class("recipe-modified")
+    panel.set_recipe(
+        replace(panel.get_recipe(), film_simulation="Acros", clarity=2)
+    )
+    assert panel.film_row.has_css_class("recipe-modified")
+    assert panel._clarity_row.has_css_class("recipe-modified")
+    assert not panel.dr_row.has_css_class("recipe-modified")
+    panel.set_active(panel.get_recipe(), "Autumn")
+    assert not panel.film_row.has_css_class("recipe-modified")
+    assert not panel._clarity_row.has_css_class("recipe-modified")
+
+
+def test_panel_starts_unmodified() -> None:
+    """A fresh panel must not count its own defaults as edits."""
+    from grawji.views.recipe_panel import RecipePanel
+
+    panel = RecipePanel()
+    pump()
+    assert not panel.is_modified
+
+
+def test_set_active_is_never_born_modified() -> None:
+    """Row normalization must not count as a user edit."""
+    from grawji.camera.capabilities import capabilities_for_model
+    from grawji.recipe import Recipe
+    from grawji.views.recipe_panel import RecipePanel
+
+    panel = RecipePanel()
+    pump()
+    panel.apply_capabilities(capabilities_for_model("X-Pro2"))
+    panel.set_active(Recipe(film_simulation="RealaAce"), "Reala look")
+    assert not panel.is_modified
+
+
+def test_modified_recipe_survives_image_open(
+    window: Any, monkeypatch: Any
+) -> None:
+    """Unsaved recipe edits carry across image switches."""
+    from dataclasses import replace
+
+    renders: list[int] = []
+    monkeypatch.setattr(window, "_render_preview", lambda: renders.append(1))
+    panel = window.recipe_panel
+    panel.set_active(panel.get_recipe(), "Summer")
+    panel.set_recipe(replace(panel.get_recipe(), film_simulation="Acros"))
+    assert panel.is_modified
+    window._on_opened(window._generation, None)
+    assert panel.active_label == "Summer"
+    assert panel.is_modified
+    assert renders == [1]
+
+
 def _manager(tmp_path: Any) -> Any:
     """A RecipeManagerDialog over a library holding ampersand names."""
     from grawji.views.recipe_manager import RecipeManagerDialog


### PR DESCRIPTION
- EV moves to its own Exposure group
- unsaved recipe edits survive image switches