### PR TITLE
fix(export): flatten alpha after rotation bake so JPEG export works on glycin runtimes

### DIFF
--- a/src/grawji/imaging/render.py
+++ b/src/grawji/imaging/render.py
@@ -214,4 +214,33 @@ def bake_pixbuf(pixbuf: Any, crop: CropRotate, *, rect: bool = True) -> Any:
     ctx.get_source().set_filter(cairo.FILTER_GOOD)
     ctx.paint()
     surface.flush()
-    return Gdk.pixbuf_get_from_surface(surface, 0, 0, cw, ch)
+    baked = Gdk.pixbuf_get_from_surface(surface, 0, 0, cw, ch)
+    return flatten_alpha(baked)
+
+
+def flatten_alpha(pixbuf: Any) -> Any:
+    """Composite an alpha pixbuf onto black, pass an RGB one through."""
+    if not pixbuf.get_has_alpha():
+        return pixbuf
+    flat = GdkPixbuf.Pixbuf.new(
+        GdkPixbuf.Colorspace.RGB,
+        False,
+        8,
+        pixbuf.get_width(),
+        pixbuf.get_height(),
+    )
+    flat.fill(0x000000FF)
+    pixbuf.composite(
+        flat,
+        0,
+        0,
+        pixbuf.get_width(),
+        pixbuf.get_height(),
+        0.0,
+        0.0,
+        1.0,
+        1.0,
+        GdkPixbuf.InterpType.NEAREST,
+        255,
+    )
+    return flat

--- a/tests/test_imaging_helpers.py
+++ b/tests/test_imaging_helpers.py
@@ -12,8 +12,11 @@ gi.require_version("GExiv2", "0.10")
 
 from gi.repository import GdkPixbuf, GExiv2
 
+from grawji.crop import CropRotate
 from grawji.imaging.imagemeta import camera_model, exif_orientation, exif_rows
 from grawji.imaging.render import (
+    bake_pixbuf,
+    flatten_alpha,
     gray_rows,
     parse_aspect,
     thumb_jpeg,
@@ -121,3 +124,27 @@ def test_thumb_jpeg_keeps_small_images_unscaled():
     loader.close()
     decoded = loader.get_pixbuf()
     assert (decoded.get_width(), decoded.get_height()) == (120, 80)
+
+
+def test_bake_with_angle_yields_no_alpha():
+    """A rotation bake comes back as 3-channel RGB (issue #100)."""
+    crop = CropRotate(angle=5.0, rect=(0.3, 0.3, 0.4, 0.4))
+    baked = bake_pixbuf(_flat_pixbuf(120, 80, 128), crop)
+    assert not baked.get_has_alpha()
+    assert baked.get_n_channels() == 3
+
+
+def test_flatten_alpha_keeps_opaque_pixels_byte_identical():
+    """Flattening changes nothing on fully opaque content."""
+    rgba = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, True, 8, 4, 4)
+    rgba.fill(0x30A0C0FF)
+    flat = flatten_alpha(rgba)
+    assert not flat.get_has_alpha()
+    pixel = bytes(flat.get_pixels()[:3])
+    assert pixel == b"\x30\xa0\xc0"
+
+
+def test_flatten_alpha_passes_rgb_through():
+    """An already-RGB pixbuf is returned as-is, not copied."""
+    rgb = _flat_pixbuf(4, 4, 90)
+    assert flatten_alpha(rgb) is rgb


### PR DESCRIPTION
Fixes #100 